### PR TITLE
feat: add FOMO urgency to landing page

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';

--- a/src/components/FacebookSDK.tsx
+++ b/src/components/FacebookSDK.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useEffect } from 'react';
 
 declare global {
@@ -12,10 +13,15 @@ declare global {
       AppEvents: {
         logPageView: () => void;
       };
-      login: (callback: (response: any) => void, options?: { scope: string }) => void;
-      logout: (callback: (response: any) => void) => void;
-      getLoginStatus: (callback: (response: any) => void) => void;
-      api: (path: string, method: string, params: any, callback: (response: any) => void) => void;
+      login: (callback: (response: unknown) => void, options?: { scope: string }) => void;
+      logout: (callback: (response: unknown) => void) => void;
+      getLoginStatus: (callback: (response: unknown) => void) => void;
+      api: (
+        path: string,
+        method: string,
+        params: Record<string, unknown>,
+        callback: (response: unknown) => void
+      ) => void;
     };
     fbAsyncInit: () => void;
   }
@@ -66,7 +72,7 @@ export const FacebookSDK = ({ appId, onReady }: FacebookSDKProps) => {
 };
 
 export const useFacebookLogin = () => {
-  const login = (callback: (response: any) => void) => {
+  const login = (callback: (response: unknown) => void) => {
     if (window.FB) {
       window.FB.login(callback, {
         scope: 'pages_manage_posts,pages_read_engagement,pages_show_list,publish_to_groups'
@@ -74,19 +80,24 @@ export const useFacebookLogin = () => {
     }
   };
 
-  const logout = (callback: (response: any) => void) => {
+  const logout = (callback: (response: unknown) => void) => {
     if (window.FB) {
       window.FB.logout(callback);
     }
   };
 
-  const getLoginStatus = (callback: (response: any) => void) => {
+  const getLoginStatus = (callback: (response: unknown) => void) => {
     if (window.FB) {
       window.FB.getLoginStatus(callback);
     }
   };
 
-  const postToPage = (pageId: string, message: string, accessToken: string, callback: (response: any) => void) => {
+  const postToPage = (
+    pageId: string,
+    message: string,
+    accessToken: string,
+    callback: (response: unknown) => void
+  ) => {
     if (window.FB) {
       window.FB.api(
         `/${pageId}/feed`,

--- a/src/components/FomoBanner.tsx
+++ b/src/components/FomoBanner.tsx
@@ -1,0 +1,30 @@
+import { AlertTriangle, Clock } from "lucide-react";
+
+interface FomoBannerProps {
+  timeLeft: number;
+  spotsLeft: number;
+}
+
+function formatTime(seconds: number) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return `${hours.toString().padStart(2, "0")}:${minutes
+    .toString()
+    .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+}
+
+export default function FomoBanner({
+  timeLeft,
+  spotsLeft,
+}: FomoBannerProps) {
+  return (
+    <div className="bg-gradient-to-r from-red-600 to-orange-500 text-white py-2 text-center font-bold flex items-center justify-center gap-2">
+      <AlertTriangle className="h-5 w-5" />
+      <span>
+        {spotsLeft} emergency spots left today — offer ends in {formatTime(timeLeft)}
+      </span>
+      <Clock className="h-5 w-5" />
+    </div>
+  );
+}

--- a/src/components/QuickCaptureForm.tsx
+++ b/src/components/QuickCaptureForm.tsx
@@ -48,7 +48,7 @@ const QuickCaptureForm = () => {
       setTimeout(() => {
         window.location.href = '/thank-you';
       }, 2000);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Form submission error:", error);
       toast({
         title: "Something went wrong",

--- a/src/components/SeoAnalysisWidget.tsx
+++ b/src/components/SeoAnalysisWidget.tsx
@@ -15,7 +15,7 @@ export function SeoAnalysisWidget() {
     // Create and append the external widget script inside the container
     const script = document.createElement("script");
     script.async = true;
-    (script as any).dataset.widgetId = "14442591191020099ff47da23fb09078659dd8a6";
+    script.dataset.widgetId = "14442591191020099ff47da23fb09078659dd8a6";
     script.src = "https://www.local-marketing-reports.com/m/assets-v2/lead-gen/js/external/widget-builder.js";
 
     // Optional: basic error handling UI

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -286,7 +286,7 @@ export const StructuredData = ({
     ]
   } : null;
 
-  const schemas: any[] = [organizationSchema, breadcrumbSchema];
+  const schemas: Record<string, unknown>[] = [organizationSchema, breadcrumbSchema];
   if (serviceSchema) schemas.push(serviceSchema);
   if (faqSchema) schemas.push(faqSchema);
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { VariantProps, cva } from "class-variance-authority";

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, toast } from "sonner";
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -62,13 +62,7 @@ const AdminDashboard = () => {
     fetchFacebookAppId();
   }, []);
 
-  useEffect(() => {
-    if (user) {
-      fetchLeads();
-    }
-  }, [user]);
-
-  const fetchLeads = async () => {
+  const fetchLeads = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('leads')
@@ -87,7 +81,13 @@ const AdminDashboard = () => {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [toast]);
+
+  useEffect(() => {
+    if (user) {
+      fetchLeads();
+    }
+  }, [user, fetchLeads]);
 
   const handleLogout = async () => {
     await signOut();

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -207,13 +207,13 @@ const Gallery = () => {
           {/* Filter Buttons */}
           <div className="flex justify-center mb-8">
             <div className="flex gap-2 p-1 bg-muted rounded-lg">
-              {['all', 'before', 'after', 'progress'].map((filter) => (
+              {(['all', 'before', 'after', 'progress'] as const).map((filter) => (
                 <Button
                   key={filter}
                   variant={filterCategory === filter ? "default" : "ghost"}
                   size="sm"
                   onClick={() => {
-                    setFilterCategory(filter as any);
+                    setFilterCategory(filter);
                     setCurrentImage(0);
                   }}
                   className="capitalize"

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -6,17 +6,18 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { SEOHead } from "@/components/SEOHead";
-import { 
-  Phone, 
-  CheckCircle, 
-  Clock, 
-  Shield, 
-  Star, 
+import {
+  Phone,
+  CheckCircle,
+  Clock,
+  Shield,
+  Star,
   AlertTriangle,
   Camera,
   Award,
   Users
 } from "lucide-react";
+import FomoBanner from "@/components/FomoBanner";
 
 interface FormData {
   name: string;
@@ -40,14 +41,23 @@ export default function LandingPage() {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [timeLeft, setTimeLeft] = useState(24 * 60 * 60); // 24 hours in seconds
+  const [spotsLeft, setSpotsLeft] = useState(3);
   const { toast } = useToast();
 
   // Countdown timer
   useEffect(() => {
     const timer = setInterval(() => {
-      setTimeLeft(prev => prev > 0 ? prev - 1 : 0);
+      setTimeLeft(prev => (prev > 0 ? prev - 1 : 0));
     }, 1000);
     return () => clearInterval(timer);
+  }, []);
+
+  // Reduce available spots over time to create urgency
+  useEffect(() => {
+    const spotTimer = setInterval(() => {
+      setSpotsLeft(prev => (prev > 1 ? prev - 1 : prev));
+    }, 300000); // every 5 minutes
+    return () => clearInterval(spotTimer);
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -84,7 +94,7 @@ export default function LandingPage() {
         urgency: "Within 24 hours", 
         message: ""
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: "Booking Failed",
         description: "Please call 0435 900 709 immediately for urgent help.",
@@ -114,16 +124,9 @@ export default function LandingPage() {
     }
   };
 
-  const formatTime = (seconds: number) => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
-
   return (
     <>
-      <SEOHead 
+      <SEOHead
         title="Emergency Roof Repairs Melbourne | Stop Leaks Fast | Call Kaids Roofing"
         description="24/7 emergency roof repair service across Melbourne. Professional leak detection & repairs. Free assessment, 10-year warranty. Call now: 0435 900 709"
         keywords="emergency roof repairs Melbourne, roof leak repair, urgent roofing service, 24/7 roof repairs, Melbourne roof emergency"
@@ -131,21 +134,19 @@ export default function LandingPage() {
         structuredData={structuredData}
       />
 
-      {/* Urgency Banner */}
-      <div className="bg-destructive text-destructive-foreground py-2 text-center text-sm font-medium">
-        <div className="container mx-auto px-4">
-          ⚡ LIMITED TIME: Free Emergency Assessment Expires in {formatTime(timeLeft)} ⚡
-        </div>
-      </div>
+      <FomoBanner timeLeft={timeLeft} spotsLeft={spotsLeft} />
 
       <div className="min-h-screen bg-gradient-to-b from-background to-secondary/10">
         {/* Hero Section */}
         <section className="pt-8 pb-12">
-          <div className="container mx-auto px-4 text-center">
-            <div className="max-w-4xl mx-auto">
-              <Badge variant="destructive" className="mb-4 text-sm font-semibold">
-                🚨 EMERGENCY ROOF REPAIRS
-              </Badge>
+            <div className="container mx-auto px-4 text-center">
+              <div className="max-w-4xl mx-auto">
+                <div className="flex flex-col items-center gap-2 mb-4">
+                  <Badge variant="destructive" className="text-sm font-semibold animate-pulse">
+                    🚨 Only {spotsLeft} emergency slots left today
+                  </Badge>
+                  <Badge className="text-sm font-semibold">EMERGENCY ROOF REPAIRS</Badge>
+                </div>
               
               <h1 className="text-4xl md:text-6xl font-bold mb-6 leading-tight">
                 Stop Your Roof Leak
@@ -279,14 +280,17 @@ export default function LandingPage() {
         <section id="emergency-form" className="py-12 bg-secondary/20">
           <div className="container mx-auto px-4">
             <div className="max-w-2xl mx-auto">
-              <Card className="shadow-2xl border-0">
-                <CardContent className="p-8">
-                  <div className="text-center mb-8">
-                    <h3 className="text-3xl font-bold mb-4">Get Your FREE Emergency Assessment</h3>
-                    <p className="text-muted-foreground">
-                      Kaidyn will personally assess your roof and provide immediate emergency protection - usually within 2 hours.
-                    </p>
-                  </div>
+                <Card className="shadow-2xl border-0">
+                  <CardContent className="p-8">
+                    <div className="text-center mb-8">
+                      <h3 className="text-3xl font-bold mb-4">Get Your FREE Emergency Assessment</h3>
+                      <p className="text-muted-foreground">
+                        Kaidyn will personally assess your roof and provide immediate emergency protection - usually within 2 hours.
+                      </p>
+                      <p className="mt-2 text-destructive font-semibold animate-pulse">
+                        Only {spotsLeft} free assessments left today!
+                      </p>
+                    </div>
 
                   <form onSubmit={handleSubmit} className="space-y-6">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -425,14 +429,17 @@ export default function LandingPage() {
         </section>
 
         {/* Final CTA */}
-        <section className="py-12 bg-primary text-primary-foreground">
-          <div className="container mx-auto px-4 text-center">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">
-              Don't Let Your Roof Emergency Get Worse
-            </h2>
-            <p className="text-xl mb-8 max-w-2xl mx-auto">
-              Every minute counts when you have a roof leak. Get professional help now and protect your biggest investment.
-            </p>
+          <section className="py-12 bg-primary text-primary-foreground">
+            <div className="container mx-auto px-4 text-center">
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">
+                Don't Let Your Roof Emergency Get Worse
+              </h2>
+              <p className="text-xl mb-8 max-w-2xl mx-auto">
+                Every minute counts when you have a roof leak. Get professional help now and protect your biggest investment.
+              </p>
+              <p className="text-lg mb-8 text-yellow-200 font-semibold animate-pulse">
+                Only {spotsLeft} emergency appointments left today.
+              </p>
             
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button size="lg" variant="secondary" className="text-lg px-8 py-6" asChild>

--- a/src/pages/RestorationLanding.tsx
+++ b/src/pages/RestorationLanding.tsx
@@ -85,7 +85,7 @@ export default function RestorationLanding() {
         urgency: "Within 2 weeks", 
         message: ""
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: "Quote Request Failed",
         description: "Please call 0435 900 709 to speak with Kaidyn directly.",

--- a/supabase/functions/send-lead-notification/index.ts
+++ b/supabase/functions/send-lead-notification/index.ts
@@ -318,7 +318,7 @@ const handler = async (req: Request): Promise<Response> => {
       }
     );
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error in send-lead-notification function:", error);
     return new Response(
       JSON.stringify({ 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -97,5 +98,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add dynamic FOMO banner component with countdown and remaining spots
- integrate banner and urgency badges across emergency landing page
- simplify FomoBanner by switching to a default export
- remove remaining `any` types, convert empty interfaces to type aliases, and switch Tailwind config to ESM import
- silence react-refresh warnings and stabilize effect dependencies in dashboard and social media manager

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c69b6db4c48320b18fc072c4dd1298