### PR TITLE
Add Facebook domain verification meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Professional Roofing Services Melbourne | Call Kaids Roofing</title>
     <meta name="description" content="Expert roof restoration, painting & emergency repairs in Southeast Melbourne. 10-year warranty, premium materials, same-day quotes. Call Kaidyn: 0435 900 709" />
+
+    <!-- Facebook domain verification -->
+    <meta
+      name="facebook-domain-verification"
+      content="EAALBPX39cAYBPUeEMD225YlMca7ZAD8GUP3PwwpuR9ioLPAZAmIKF1HHQ5ognKbZAh27cZBy3NsZApoHN04uJ1ME8ZCR70HZBKZAlCJJbMMmp4PKrzyIbQVW3ZBlKFZCMppzjgtEK4p158BpVwJXwUxM73ZCYnB0OUmh7cnVQK373Cg8pJALUvxPMy376D06PkuZAVjZCLQZDZD"
+    />
     
     <!-- Performance optimizations -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- add Facebook domain verification meta tag to index.html

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b95b6e54832085884e1d7cd2bc3a