### PR TITLE
Implement SEO canonical updates and suburb landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Professional Roofing Services Melbourne | Call Kaids Roofing</title>
-    <meta name="description" content="Expert roof restoration, painting & emergency repairs in Southeast Melbourne. 10-year warranty, premium materials, same-day quotes. Call Kaidyn: 0435 900 709" />
+    <link rel="canonical" href="https://www.callkaidsroofing.com.au/" />
+    <title>Call Kaids Roofing | Roof Restorations Clyde North &amp; SE Melbourne</title>
+    <meta name="description" content="Local roofing experts in Clyde North. Roof restorations, painting, repairs &amp; gutter cleaning with 10-year warranty. Call 0435 900 709 today." />
 
     <!-- Facebook domain verification -->
     <meta
@@ -13,6 +14,21 @@
       content="EAALBPX39cAYBPUeEMD225YlMca7ZAD8GUP3PwwpuR9ioLPAZAmIKF1HHQ5ognKbZAh27cZBy3NsZApoHN04uJ1ME8ZCR70HZBKZAlCJJbMMmp4PKrzyIbQVW3ZBlKFZCMppzjgtEK4p158BpVwJXwUxM73ZCYnB0OUmh7cnVQK373Cg8pJALUvxPMy376D06PkuZAVjZCLQZDZD"
     />
     
+    <script>
+      (function enforceCanonicalDomain() {
+        var canonicalHost = "www.callkaidsroofing.com.au";
+        if (typeof window === "undefined") return;
+        var hostname = window.location.hostname;
+        if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+          return;
+        }
+        if (hostname !== canonicalHost || window.location.protocol !== "https:") {
+          var newUrl = "https://" + canonicalHost + window.location.pathname + window.location.search + window.location.hash;
+          window.location.replace(newUrl);
+        }
+      })();
+    </script>
+
     <!-- Performance optimizations -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -55,8 +71,8 @@
     <meta property="og:title" content="Call Kaids Roofing | Professional Roof Services Melbourne" />
     <meta property="og:description" content="Professional roofing services in Melbourne. Roof restoration, painting, emergency repairs with 10-year warranty. Call 0435 900 709." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://callkaidsroofing-com-au.lovable.app/" />
-    <meta property="og:image" content="https://callkaidsroofing-com-au.lovable.app/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
+    <meta property="og:url" content="https://www.callkaidsroofing.com.au/" />
+    <meta property="og:image" content="https://www.callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
     <meta property="og:locale" content="en_AU" />
     <meta property="og:site_name" content="Call Kaids Roofing" />
 
@@ -64,7 +80,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Call Kaids Roofing | Professional Roof Services Melbourne" />
     <meta name="twitter:description" content="Professional roofing services with 10-year warranty. Serving Melbourne SE suburbs." />
-    <meta name="twitter:image" content="https://callkaidsroofing-com-au.lovable.app/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
+    <meta name="twitter:image" content="https://www.callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
     <meta name="twitter:site" content="@callkaidsroofing" />
     <meta name="twitter:creator" content="@callkaidsroofing" />
     
@@ -81,7 +97,7 @@
       "@type": "RoofingContractor",
       "name": "Call Kaids Roofing",
       "description": "Professional roofing services across Southeast Melbourne. Roof restoration, painting, emergency repairs with 10-year workmanship warranty.",
-      "url": "https://callkaidsroofing-com-au.lovable.app",
+      "url": "https://www.callkaidsroofing.com.au",
       "telephone": "+61 435 900 709",
       "email": "callkaidsroofing@outlook.com",
       "address": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -16,7 +16,7 @@ Disallow: /admin/
 Disallow: /private/
 
 # Sitemaps
-Sitemap: https://callkaidsroofing.com.au/sitemap.xml
+Sitemap: https://www.callkaidsroofing.com.au/sitemap.xml
 
 # Crawl delay for respectful crawling
 Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,131 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://callkaidsroofing.com.au/</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing.com.au/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing.com.au/" />
-    <lastmod>2025-01-15</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/services/roof-restoration</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/services/roof-restoration" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/services/roof-restoration" />
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.90</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/services/roof-painting</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/services/roof-painting" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/services/roof-painting" />
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.90</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/services/roof-repairs</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/services/roof-repairs" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/services/roof-repairs" />
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.90</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/services/gutter-cleaning</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/services/gutter-cleaning" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/services/gutter-cleaning" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/about</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/services/valley-iron-replacement</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/services/valley-iron-replacement" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/services/valley-iron-replacement" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/contact</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/about</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/about" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/about" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/gallery</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/contact</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/contact" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/contact" />
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.80</priority>
+    <loc>https://www.callkaidsroofing.com.au/blog</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.65</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/emergency</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/emergency" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/emergency" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/emergency</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
+    <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/warranty</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/warranty" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/warranty" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/warranty</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.60</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/privacy-policy</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/privacy-policy" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/privacy-policy" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/privacy-policy</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.50</priority>
+    <priority>0.40</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/roof-restoration</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/roof-restoration" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/roof-restoration" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.95</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/roof-painting</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/roof-painting" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/roof-painting" />
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/roof-repointing</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/roof-repointing" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/roof-repointing" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-clyde-north</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.90</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/tile-replacement</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/tile-replacement" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/tile-replacement" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-cranbourne</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-pakenham</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-berwick</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-mount-eliza</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing-com-au.lovable.app/leak-detection</loc>
-    <xhtml:link rel="alternate" hreflang="en-AU" href="https://callkaidsroofing-com-au.lovable.app/leak-detection" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://callkaidsroofing-com-au.lovable.app/leak-detection" />
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-painting</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.92</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-pakenham</loc>
+    <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-cranbourne</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-clyde-north</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.88</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-repairs</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.90</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/gutter-cleaning</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/valley-iron-replacement</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/roof-repointing</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.70</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/tile-replacement</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.70</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/services/leak-detection</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.70</priority>
+  </url>
+  <url>
+    <loc>https://www.callkaidsroofing.com.au/book</loc>
+    <lastmod>2024-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.60</priority>
   </url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,14 @@ import ThankYou from "./pages/ThankYou";
 import AdminLogin from "./pages/AdminLogin";
 import AdminDashboard from "./pages/AdminDashboard";
 import RestorationLanding from "./pages/RestorationLanding";
+import RoofRestorationClydeNorth from "./pages/services/suburbs/RoofRestorationClydeNorth";
+import RoofRestorationCranbourne from "./pages/services/suburbs/RoofRestorationCranbourne";
+import RoofRestorationPakenham from "./pages/services/suburbs/RoofRestorationPakenham";
+import RoofRestorationBerwick from "./pages/services/suburbs/RoofRestorationBerwick";
+import RoofRestorationMountEliza from "./pages/services/suburbs/RoofRestorationMountEliza";
+import RoofPaintingPakenham from "./pages/services/suburbs/RoofPaintingPakenham";
+import RoofPaintingCranbourne from "./pages/services/suburbs/RoofPaintingCranbourne";
+import RoofPaintingClydeNorth from "./pages/services/suburbs/RoofPaintingClydeNorth";
 
 const queryClient = new QueryClient();
 
@@ -69,6 +77,14 @@ function App() {
                   <Route path="services" element={<Index />} />
                   <Route path="services/roof-restoration" element={<RoofRestoration />} />
                   <Route path="services/roof-painting" element={<RoofPainting />} />
+                  <Route path="services/roof-restoration-clyde-north" element={<RoofRestorationClydeNorth />} />
+                  <Route path="services/roof-restoration-cranbourne" element={<RoofRestorationCranbourne />} />
+                  <Route path="services/roof-restoration-pakenham" element={<RoofRestorationPakenham />} />
+                  <Route path="services/roof-restoration-berwick" element={<RoofRestorationBerwick />} />
+                  <Route path="services/roof-restoration-mount-eliza" element={<RoofRestorationMountEliza />} />
+                  <Route path="services/roof-painting-pakenham" element={<RoofPaintingPakenham />} />
+                  <Route path="services/roof-painting-cranbourne" element={<RoofPaintingCranbourne />} />
+                  <Route path="services/roof-painting-clyde-north" element={<RoofPaintingClydeNorth />} />
                   <Route path="services/roof-repairs" element={<RoofRepairs />} />
                   <Route path="services/gutter-cleaning" element={<GutterCleaning />} />
                   <Route path="services/valley-iron-replacement" element={<ValleyIronReplacement />} />

--- a/src/components/ElegantLayout.tsx
+++ b/src/components/ElegantLayout.tsx
@@ -88,6 +88,14 @@ export const ElegantLayout = () => {
         <Footer />
       </div>
 
+      <a
+        href="tel:0435900709"
+        className="md:hidden fixed bottom-6 left-4 right-4 z-50 inline-flex items-center justify-center gap-2 rounded-full bg-primary text-primary-foreground py-3 font-semibold shadow-2xl shadow-primary/40 hover:bg-primary/90 transition-all"
+      >
+        <Phone className="h-5 w-5" />
+        Call Now • 0435 900 709
+      </a>
+
       <ScrollToTop />
     </div>
   );

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+type GtagFunction = (...args: unknown[]) => void;
+
 declare global {
   interface Window {
-    gtag: any;
-    dataLayer: any[];
+    gtag?: GtagFunction;
+    dataLayer: unknown[];
   }
 }
 
@@ -19,8 +21,8 @@ export const GoogleAnalytics = ({ measurementId }: GoogleAnalyticsProps) => {
     // Initialize Google Analytics
     if (typeof window !== 'undefined') {
       window.dataLayer = window.dataLayer || [];
-      window.gtag = function() {
-        window.dataLayer.push(arguments);
+      window.gtag = (...args: unknown[]) => {
+        window.dataLayer.push(args);
       };
       
       // Load GA script

--- a/src/components/LocalBusinessSchema.tsx
+++ b/src/components/LocalBusinessSchema.tsx
@@ -6,28 +6,28 @@ interface LocalBusinessSchemaProps {
   suburb?: string;
 }
 
-export const LocalBusinessSchema = ({ 
-  pageName = "Home", 
+export const LocalBusinessSchema = ({
+  pageName = "Home",
   serviceType,
-  suburb 
+  suburb
 }: LocalBusinessSchemaProps) => {
-  const baseSchema = {
+  const baseSchema: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
-    "@id": "https://callkaidsroofing.com.au/#organization",
+    "@id": "https://www.callkaidsroofing.com.au/#organization",
     name: "Call Kaids Roofing",
     alternateName: "Kaids Roofing",
     description: `Professional roofing services in ${suburb || 'Southeast Melbourne'} specializing in ${serviceType || 'roof restoration, painting and emergency repairs'}`,
-    url: "https://callkaidsroofing.com.au",
+    url: "https://www.callkaidsroofing.com.au",
     logo: {
       "@type": "ImageObject",
-      url: "https://callkaidsroofing.com.au/logo.png",
+      url: "https://www.callkaidsroofing.com.au/logo.png",
       width: 300,
       height: 200
     },
     image: {
       "@type": "ImageObject",
-      url: "https://callkaidsroofing.com.au/og-image.jpg",
+      url: "https://www.callkaidsroofing.com.au/og-image.jpg",
       width: 1200,
       height: 630
     },
@@ -101,7 +101,7 @@ export const LocalBusinessSchema = ({
   };
 
   // Add service-specific schema if provided
-  const serviceSchema = serviceType ? {
+  const serviceSchema: Record<string, unknown> | null = serviceType ? {
     "@context": "https://schema.org",
     "@type": "Service",
     name: serviceType,
@@ -131,7 +131,7 @@ export const LocalBusinessSchema = ({
   } : null;
 
   // Create breadcrumb schema for better navigation understanding
-  const breadcrumbSchema = {
+  const breadcrumbSchema: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
@@ -139,29 +139,29 @@ export const LocalBusinessSchema = ({
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: "https://callkaidsroofing.com.au/"
+        item: "https://www.callkaidsroofing.com.au/"
       },
       ...(serviceType ? [{
         "@type": "ListItem",
         position: 2,
         name: "Services",
-        item: "https://callkaidsroofing.com.au/services"
+        item: "https://www.callkaidsroofing.com.au/services"
       }, {
         "@type": "ListItem",
         position: 3,
         name: serviceType,
-        item: `https://callkaidsroofing.com.au/services/${serviceType.toLowerCase().replace(/\s+/g, '-')}`
+        item: `https://www.callkaidsroofing.com.au/services/${serviceType.toLowerCase().replace(/\s+/g, '-')}`
       }] : pageName !== "Home" ? [{
         "@type": "ListItem",
         position: 2,
         name: pageName,
-        item: `https://callkaidsroofing.com.au/${pageName.toLowerCase()}`
+        item: `https://www.callkaidsroofing.com.au/${pageName.toLowerCase()}`
       }] : [])
     ]
   };
 
-  const schemas = [baseSchema, breadcrumbSchema];
-  if (serviceSchema) schemas.push(serviceSchema as any);
+  const schemas: Record<string, unknown>[] = [baseSchema, breadcrumbSchema];
+  if (serviceSchema) schemas.push(serviceSchema);
 
   return (
     <Helmet>

--- a/src/components/MetaPixelTracker.tsx
+++ b/src/components/MetaPixelTracker.tsx
@@ -1,9 +1,14 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+type FbqFunction = ((...args: unknown[]) => void) & {
+  loaded?: boolean;
+  q?: unknown[];
+};
+
 declare global {
   interface Window {
-    fbq: any;
+    fbq?: FbqFunction;
   }
 }
 
@@ -20,47 +25,25 @@ export const MetaPixelTracker = () => {
   useEffect(() => {
     // Initialize Meta Pixel
     if (typeof window !== 'undefined') {
-      window.fbq = window.fbq || function() {
-        (window.fbq.q = window.fbq.q || []).push(arguments);
-      };
-      
+      if (!window.fbq) {
+        const fbq: FbqFunction = (...args: unknown[]) => {
+          (fbq.q = fbq.q || []).push(args);
+        };
+        window.fbq = fbq;
+      }
+
       if (!window.fbq.loaded) {
         const script = document.createElement('script');
         script.async = true;
         script.src = 'https://connect.facebook.net/en_US/fbevents.js';
         document.head.appendChild(script);
-        
+
         window.fbq('init', 'YOUR_PIXEL_ID_HERE'); // Replace with actual pixel ID
         window.fbq('track', 'PageView');
         window.fbq.loaded = true;
       }
     }
   }, []);
-
-  // Track custom events
-  const trackEvent = (eventName: string, parameters?: any) => {
-    if (typeof window !== 'undefined' && window.fbq) {
-      window.fbq('track', eventName, parameters);
-    }
-  };
-
-  // Track lead events
-  const trackLead = (value?: number, currency = 'AUD') => {
-    trackEvent('Lead', { value, currency });
-  };
-
-  // Track contact events
-  const trackContact = () => {
-    trackEvent('Contact');
-  };
-
-  // Track quote requests
-  const trackQuoteRequest = (serviceType?: string) => {
-    trackEvent('SubmitApplication', { 
-      content_name: 'Quote Request',
-      content_category: serviceType || 'General'
-    });
-  };
 
   return null;
 };

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from 'react-helmet-async';
+import { useLocation } from 'react-router-dom';
 
 interface SEOHeadProps {
   title?: string;
@@ -10,217 +11,44 @@ interface SEOHeadProps {
 }
 
 export const SEOHead = ({
-  title = "Professional Roofing Services Melbourne | Call Kaids Roofing | 10 Year Warranty",
-  description = "Expert roof restoration, painting & emergency repairs in Southeast Melbourne. 10-year warranty, premium materials, same-day quotes. Call Kaidyn: 0435 900 709",
-  keywords = "roof restoration Melbourne, roof painting Melbourne, emergency roof repairs, Clyde North roofer, Berwick roofing, Southeast Melbourne roofing, roof maintenance Melbourne",
+  title = "Call Kaids Roofing | Roof Restorations Clyde North & SE Melbourne",
+  description = "Local roofing experts in Clyde North. Roof restorations, painting, repairs & gutter cleaning with 10-year warranty. Call 0435 900 709 today.",
+  keywords = "roof restoration Clyde North, roof painting Clyde North, roof repairs Southeast Melbourne, local roofing contractor, Call Kaids Roofing",
   canonical,
-  ogImage = "https://callkaidsroofing.com.au/og-image.jpg",
+  ogImage = "https://www.callkaidsroofing.com.au/og-image.jpg",
   structuredData
 }: SEOHeadProps) => {
+  const location = useLocation();
+
+  const canonicalUrl = canonical || `https://www.callkaidsroofing.com.au${location.pathname}${location.search}`;
+
   const defaultStructured = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
-    "@id": "https://callkaidsroofing.com.au/#organization",
     name: "Call Kaids Roofing",
-    legalName: "Call Kaids Roofing",
-    description,
-    url: "https://callkaidsroofing.com.au",
-    logo: "https://callkaidsroofing.com.au/logo.png",
-    image: ogImage,
-    telephone: "+61435900709",
+    url: "https://www.callkaidsroofing.com.au",
+    telephone: "+61-435-900-709",
     email: "callkaidsroofing@outlook.com",
-    foundingDate: "2020",
-    founder: {
-      "@type": "Person",
-      name: "Kaidyn Brownlie"
-    },
     address: {
       "@type": "PostalAddress",
-      streetAddress: "Grices Rd",
       addressLocality: "Clyde North",
       addressRegion: "VIC",
       postalCode: "3978",
       addressCountry: "AU"
     },
-    areaServed: [
-      {
-        "@type": "City",
-        name: "Clyde North",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City", 
-        name: "Berwick",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Officer", 
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Pakenham",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Cranbourne",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Cranbourne North",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Cranbourne East",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Narre Warren",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Doveton",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Dandenong",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      },
-      {
-        "@type": "City",
-        name: "Rowville",
-        containedInPlace: { "@type": "State", name: "Victoria" }
-      }
-    ],
-    serviceArea: {
+    identifier: "ABN 39475055075",
+    areaServed: {
       "@type": "GeoCircle",
-      geoMidpoint: { 
-        "@type": "GeoCoordinates", 
-        latitude: -38.1167, 
-        longitude: 145.3333 
+      geoMidpoint: {
+        "@type": "GeoCoordinates",
+        latitude: -38.09,
+        longitude: 145.33
       },
       geoRadius: "50000"
     },
-    hasOfferCatalog: {
-      "@type": "OfferCatalog",
-      name: "Roofing Services",
-      itemListElement: [
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service",
-            name: "Roof Restoration",
-            description: "Complete roof restoration including cleaning, repairs, and painting with 10-year warranty"
-          }
-        },
-        {
-          "@type": "Offer", 
-          itemOffered: {
-            "@type": "Service",
-            name: "Roof Painting",
-            description: "Professional roof painting services with premium Dulux AcraTex and Colorbond materials"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Emergency Roof Repairs",
-            description: "24/7 emergency roof repair services across Southeast Melbourne with same-day response"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Gutter Cleaning",
-            description: "Professional gutter cleaning and maintenance services"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Leak Detection",
-            description: "Expert leak detection and repair services with thermal imaging"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Ridge Capping",
-            description: "Ridge cap rebedding and repointing with flexible pointing compound"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Tile Replacement",
-            description: "Broken and damaged roof tile replacement services"
-          }
-        },
-        {
-          "@type": "Offer",
-          itemOffered: {
-            "@type": "Service", 
-            name: "Valley Iron Replacement",
-            description: "Valley iron and flashing replacement with Colorbond steel"
-          }
-        }
-      ]
-    },
-    openingHoursSpecification: [
-      {
-        "@type": "OpeningHoursSpecification",
-        dayOfWeek: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
-        opens: "07:00",
-        closes: "18:00"
-      }
-    ],
-    currenciesAccepted: "AUD",
-    priceRange: "$$",
-    aggregateRating: {
-      "@type": "AggregateRating",
-      ratingValue: "4.9",
-      reviewCount: "47",
-      bestRating: "5",
-      worstRating: "1"
-    },
-    identifier: {
-      "@type": "PropertyValue",
-      name: "ABN",
-      value: "39475055075"
-    },
     sameAs: [
       "https://www.facebook.com/callkaidsroofing",
-      "https://www.instagram.com/callkaidsroofing",
-      "https://tradiesnearyou.com.au/trades/roofers/victoria/clyde-north/call-kaids-roofing",
-      "https://www.serviceseeking.com.au/profile/308109-call-kaids-roofing"
-    ],
-    hasCredential: [
-      {
-        "@type": "EducationalOccupationalCredential",
-        credentialCategory: "license",
-        name: "Fully Insured Roofing Contractor"
-      }
-    ],
-    makesOffer: [
-      {
-        "@type": "Offer",
-        name: "Free Roof Health Check",
-        description: "Complimentary roof inspection and assessment",
-        price: "0",
-        priceCurrency: "AUD"
-      }
+      "https://www.instagram.com/callkaidsroofing"
     ]
   };
 
@@ -229,8 +57,8 @@ export const SEOHead = ({
       <title>{title}</title>
       <meta name="description" content={description} />
       <meta name="keywords" content={keywords} />
-      {canonical && <link rel="canonical" href={canonical} />}
-      <link rel="alternate" href={canonical || 'https://callkaidsroofing.com.au/'} hrefLang="en-AU" />
+      <link rel="canonical" href={canonicalUrl} />
+      <link rel="alternate" href={canonicalUrl} hrefLang="en-AU" />
       <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
       <meta name="author" content="Call Kaids Roofing" />
       <meta name="copyright" content="Call Kaids Roofing" />
@@ -248,7 +76,7 @@ export const SEOHead = ({
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
       <meta property="og:image:alt" content="Call Kaids Roofing - Professional Roof Services" />
-      {canonical && <meta property="og:url" content={canonical} />}
+      <meta property="og:url" content={canonicalUrl} />
       <meta property="og:locale" content="en_AU" />
       <meta property="og:site_name" content="Call Kaids Roofing" />
       

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -17,23 +17,23 @@ export const StructuredData = ({
   const organizationSchema = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
-    "@id": "https://callkaidsroofing.com.au/#organization",
+    "@id": "https://www.callkaidsroofing.com.au/#organization",
     name: "Call Kaids Roofing",
     legalName: "Call Kaids Roofing",
     alternateName: ["Kaids Roofing", "Call Kaids"],
     description: "Professional roofing services in Southeast Melbourne specializing in roof restoration, painting, and emergency repairs with 10-year warranty.",
-    url: "https://callkaidsroofing.com.au",
+    url: "https://www.callkaidsroofing.com.au",
     logo: {
       "@type": "ImageObject",
-      url: "https://callkaidsroofing.com.au/logo.png",
+      url: "https://www.callkaidsroofing.com.au/logo.png",
       width: "300",
       height: "100"
     },
     image: [
-      "https://callkaidsroofing.com.au/og-image.jpg",
-      "https://callkaidsroofing.com.au/assets/hero-roof-restoration.jpg"
+      "https://www.callkaidsroofing.com.au/og-image.jpg",
+      "https://www.callkaidsroofing.com.au/assets/hero-roof-restoration.jpg"
     ],
-    telephone: "+61435900709",
+    telephone: "+61-435-900-709",
     email: "callkaidsroofing@outlook.com",
     foundingDate: "2020",
     founder: {
@@ -103,11 +103,11 @@ export const StructuredData = ({
           "@type": "Offer",
           itemOffered: {
             "@type": "Service",
-            "@id": "https://callkaidsroofing.com.au/services/roof-restoration",
+            "@id": "https://www.callkaidsroofing.com.au/services/roof-restoration",
             name: "Roof Restoration Melbourne",
             description: "Complete roof restoration including high-pressure cleaning, repairs, and premium membrane coating with 10-year warranty.",
-            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$6,000 - $30,000",
@@ -119,11 +119,11 @@ export const StructuredData = ({
           "@type": "Offer", 
           itemOffered: {
             "@type": "Service",
-            "@id": "https://callkaidsroofing.com.au/services/roof-painting",
+            "@id": "https://www.callkaidsroofing.com.au/services/roof-painting",
             name: "Roof Painting Melbourne",
             description: "Professional roof painting with premium weather-resistant paints, completed in 2-3 days with 10-year warranty.",
-            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$4,000 - $18,000",
@@ -135,11 +135,11 @@ export const StructuredData = ({
           "@type": "Offer",
           itemOffered: {
             "@type": "Service", 
-            "@id": "https://callkaidsroofing.com.au/services/roof-repairs",
+            "@id": "https://www.callkaidsroofing.com.au/services/roof-repairs",
             name: "Emergency Roof Repairs Melbourne",
             description: "24/7 emergency roof repair services for leaks, storm damage, and urgent roofing issues across Southeast Melbourne.",
-            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$150 - $2,000",
@@ -210,18 +210,18 @@ export const StructuredData = ({
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: "https://callkaidsroofing.com.au/"
+        item: "https://www.callkaidsroofing.com.au/"
       },
       ...(type === 'service' && serviceName ? [{
         "@type": "ListItem",
         position: 2,
         name: "Services",
-        item: "https://callkaidsroofing.com.au/services"
+        item: "https://www.callkaidsroofing.com.au/services"
       }, {
         "@type": "ListItem",
         position: 3,
         name: serviceName,
-        item: pageUrl || `https://callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`
+        item: pageUrl || `https://www.callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`
       }] : [])
     ]
   };
@@ -229,11 +229,11 @@ export const StructuredData = ({
   const serviceSchema = serviceName ? {
     "@context": "https://schema.org",
     "@type": "Service",
-    "@id": pageUrl || `https://callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`,
+    "@id": pageUrl || `https://www.callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`,
     name: serviceName,
     description: serviceDescription || `Professional ${serviceName.toLowerCase()} services in Southeast Melbourne by Call Kaids Roofing.`,
-    provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
-    areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
+    provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
+    areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
     category: "Roofing Services",
     hasOfferCatalog: {
       "@type": "OfferCatalog",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,10 +1,16 @@
 import { Button } from '@/components/ui/button';
+import { SEOHead } from '@/components/SEOHead';
 import { Phone, MapPin, Award, Users, Clock, Shield } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const About = () => {
   return (
     <div className="min-h-screen">
+      <SEOHead
+        title="About Call Kaids Roofing | Clyde North Roofing Specialist"
+        description="Meet Kaidyn Brownlie – the Clyde North local behind Call Kaids Roofing. Discover the story, service area and workmanship that sets our SE Melbourne roofing crew apart."
+        keywords="Call Kaids Roofing about, Clyde North roofer story, local roofing specialist"
+      />
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-br from-primary/5 to-primary/10">
         <div className="container mx-auto px-4">

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Helmet } from "react-helmet-async";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,6 +8,7 @@ import { OptimizedImage } from "@/components/OptimizedImage";
 import { Clock, User, ArrowRight, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { SeoAnalysisWidget } from "@/components/SeoAnalysisWidget";
+import { SEOHead } from "@/components/SEOHead";
 
 export default function Blog() {
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
@@ -27,12 +27,11 @@ export default function Blog() {
 
   return (
     <>
-      <Helmet>
-        <title>Roofing Blog - Expert Tips & Guides | Call Kaids Roofing Melbourne</title>
-        <meta name="description" content="Expert roofing advice, maintenance tips, and industry insights for Melbourne homeowners. Professional guides on roof restoration, repairs, and protection." />
-        <meta name="keywords" content="roofing blog, Melbourne roofing tips, roof maintenance guides, roofing advice, Call Kaids Roofing" />
-        <link rel="canonical" href="https://callkaidsroofing.com.au/blog" />
-      </Helmet>
+      <SEOHead
+        title="Roofing Blog - Expert Tips & Guides | Call Kaids Roofing"
+        description="Expert roofing advice, maintenance tips, and industry insights for Melbourne homeowners. Professional guides on roof restoration, repairs, and protection."
+        keywords="roofing blog, Melbourne roofing tips, roof maintenance guides, roofing advice, Call Kaids Roofing"
+      />
 
       <div className="min-h-screen bg-gradient-to-br from-background via-background/50 to-primary/5">
         {/* Hero Section */}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,5 +1,4 @@
 import { useParams, Link, Navigate } from "react-router-dom";
-import { Helmet } from "react-helmet-async";
 import { blogPosts, blogCategories } from "@/data/blogPosts";
 import { OptimizedImage } from "@/components/OptimizedImage";
 import { Badge } from "@/components/ui/badge";
@@ -7,6 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Clock, User, ArrowLeft, ArrowRight, Share2, Calendar } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
+import { Helmet } from "react-helmet-async";
+import { SEOHead } from "@/components/SEOHead";
 
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
@@ -36,13 +37,13 @@ export default function BlogPost() {
 
   return (
     <>
+      <SEOHead
+        title={`${post.title} | Call Kaids Roofing Blog`}
+        description={post.excerpt}
+        keywords={post.tags.join(", ")}
+      />
+
       <Helmet>
-        <title>{post.title} | Call Kaids Roofing Blog</title>
-        <meta name="description" content={post.excerpt} />
-        <meta name="keywords" content={post.tags.join(", ")} />
-        <link rel="canonical" href={`https://callkaidsroofing.com.au/blog/${post.slug}`} />
-        
-        {/* Open Graph */}
         <meta property="og:title" content={post.title} />
         <meta property="og:description" content={post.excerpt} />
         <meta property="og:image" content={post.imageUrl} />

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -187,11 +187,10 @@ const BookingPage = () => {
 
   return (
     <>
-      <SEOHead 
+      <SEOHead
         title="Book Your Free Roof Quote | Call Kaids Roofing | Same Day Response"
         description="Book your free roof quote today. Same-day response, 10-year warranty, premium materials. Serving all Southeast Melbourne suburbs. Call 0435 900 709"
         keywords="book roof quote Melbourne, free roof inspection, roof quote Clyde North, emergency roof repairs booking"
-        canonical="https://callkaidsroofing.com.au/booking"
       />
       <StructuredData type="contact" />
       

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -11,7 +11,6 @@ const Contact = () => {
         title="Contact Call Kaids Roofing | Direct to Owner | Southeast Melbourne"
         description="Talk direct to Kaidyn Brownlie, owner of Call Kaids Roofing. No call centres, no BS. Phone 0435 900 709 for immediate response. Free quotes, emergency repairs."
         keywords="contact roofer Melbourne, Clyde North roofing, emergency roof repairs, free roof quote, direct contact roofer"
-        canonical="https://callkaidsroofing.com.au/contact"
       />
       <div className="min-h-screen">
       {/* Hero Section */}

--- a/src/pages/Emergency.tsx
+++ b/src/pages/Emergency.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { SEOHead } from '@/components/SEOHead';
 import { Phone, Clock, MapPin, AlertTriangle, CheckCircle, Shield } from 'lucide-react';
 
 const Emergency = () => {
@@ -29,6 +30,11 @@ const Emergency = () => {
 
   return (
     <div className="min-h-screen">
+      <SEOHead
+        title="Emergency Roof Repairs Clyde North & SE Melbourne | Call Kaids Roofing"
+        description="Same-day emergency roof repairs for Clyde North, Cranbourne, Berwick and surrounding suburbs. Call 0435 900 709 for rapid leak control and storm damage support."
+        keywords="emergency roof repairs Clyde North, storm damage roofing Melbourne, urgent roof repair"
+      />
       {/* Hero Section */}
       <section className="py-20 bg-destructive text-destructive-foreground">
         <div className="container mx-auto px-4">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -57,12 +57,11 @@ const Index = () => {
 
   return (
     <>
-      <SEOHead 
-        title="Professional Roofing Services Melbourne | Call Kaids Roofing | 10 Year Warranty"
-        description="Expert roof restoration, painting & emergency repairs in Southeast Melbourne. 10-year warranty, premium materials, same-day quotes. Call Kaidyn: 0435 900 709"
-        keywords="roof restoration Melbourne, roof painting Melbourne, emergency roof repairs, Clyde North roofer, Berwick roofing, Southeast Melbourne roofing"
-        canonical="https://callkaidsroofing.com.au/"
-        ogImage="https://callkaidsroofing.com.au/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
+      <SEOHead
+        title="Call Kaids Roofing | Roof Restorations Clyde North & SE Melbourne"
+        description="Local roofing experts in Clyde North. Roof restorations, painting, repairs & gutter cleaning with 10-year warranty. Call 0435 900 709 today."
+        keywords="roof restorations Clyde North, roof painting southeast Melbourne, gutter cleaning Clyde North, roof repairs Berwick"
+        ogImage="https://www.callkaidsroofing.com.au/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
       />
       <StructuredData type="homepage" />
       <div className="page-transition">

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -130,7 +130,6 @@ export default function LandingPage() {
         title="Emergency Roof Repairs Melbourne | Stop Leaks Fast | Call Kaids Roofing"
         description="24/7 emergency roof repair service across Melbourne. Professional leak detection & repairs. Free assessment, 10-year warranty. Call now: 0435 900 709"
         keywords="emergency roof repairs Melbourne, roof leak repair, urgent roofing service, 24/7 roof repairs, Melbourne roof emergency"
-        canonical="https://callkaidsroofing.com.au/emergency-landing"
         structuredData={structuredData}
       />
 

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -6,7 +6,6 @@ export default function PrivacyPolicy() {
       <SEOHead
         title="Privacy Policy | Call Kaids Roofing"
         description="Privacy policy for Call Kaids Roofing. Learn how we collect, use and protect your personal information."
-        canonical="https://callkaidsroofing.com.au/privacy-policy"
       />
       
       <div className="min-h-screen bg-background">
@@ -23,7 +22,7 @@ export default function PrivacyPolicy() {
                 <h2 className="text-2xl font-semibold text-foreground mb-4">Who We Are</h2>
                 <p>
                   Call Kaids Roofing (ABN: 39475055075) is a roofing contractor based in Clyde North, Victoria. 
-                  Our website address is: https://callkaidsroofing.com.au
+                  Our website address is: https://www.callkaidsroofing.com.au
                 </p>
               </section>
 

--- a/src/pages/RestorationLanding.tsx
+++ b/src/pages/RestorationLanding.tsx
@@ -124,11 +124,10 @@ export default function RestorationLanding() {
 
   return (
     <>
-      <SEOHead 
+      <SEOHead
         title="Roof Restoration Melbourne | Transform Your Roof | Call Kaids Roofing"
         description="Professional roof restoration services across Melbourne. Complete roof makeover with painting, repointing & repairs. 10-year warranty. Free health check."
         keywords="roof restoration Melbourne, roof painting Melbourne, roof repointing, complete roof makeover, Melbourne roof restoration"
-        canonical="https://callkaidsroofing.com.au/restoration-landing"
         structuredData={structuredData}
       />
 

--- a/src/pages/Warranty.tsx
+++ b/src/pages/Warranty.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { SEOHead } from '@/components/SEOHead';
 import { Shield, CheckCircle, Phone, Clock, Award, AlertTriangle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
@@ -70,6 +71,11 @@ const Warranty = () => {
 
   return (
     <div className="min-h-screen">
+      <SEOHead
+        title="Roofing Warranty | 10-Year Workmanship Guarantee | Call Kaids Roofing"
+        description="Understand the 10-year workmanship and material warranty from Call Kaids Roofing. Covering Clyde North, Cranbourne, Berwick & SE Melbourne projects."
+        keywords="roofing warranty Melbourne, roof restoration warranty, Call Kaids Roofing guarantee"
+      />
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-br from-primary/5 to-primary/10">
         <div className="container mx-auto px-4">

--- a/src/pages/services/LeakDetection.tsx
+++ b/src/pages/services/LeakDetection.tsx
@@ -29,7 +29,7 @@ const LeakDetection = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Leak Detection",
-    "url": "https://callkaidsroofing.com.au/leak-detection"
+    "url": "https://www.callkaidsroofing.com.au/leak-detection"
   };
 
   return (
@@ -38,7 +38,6 @@ const LeakDetection = () => {
         title="Roof Leak Detection Melbourne | Emergency Leak Repair | Call Kaids Roofing"
         description="Professional roof leak detection in Southeast Melbourne. Find hidden leaks fast with advanced techniques. Emergency service available. Call 0435 900 709."
         keywords="roof leak detection Melbourne, roof leak repair, emergency roof repair, hidden roof leaks, Clyde North leak detection"
-        canonical="https://callkaidsroofing.com.au/leak-detection"
         structuredData={structuredData}
       />
 

--- a/src/pages/services/RoofPainting.tsx
+++ b/src/pages/services/RoofPainting.tsx
@@ -92,17 +92,16 @@ const RoofPainting = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead 
-        title="Roof Painting Melbourne | 3 Day Transformation | Premium Paints | 10 Year Warranty"
-        description="Professional roof painting Melbourne. Transform your home in 3 days with premium weather-resistant paints. $4,000-$10,000. Call 0435 900 709"
-        keywords="roof painting Melbourne, roof painting Clyde North, roof painting Berwick, professional roof painting, Melbourne roof painters"
-        canonical="https://callkaidsroofing.com.au/services/roof-painting"
+      <SEOHead
+        title="Roof Painting Melbourne | Tile & Metal Roof Coatings"
+        description="Transform your home’s look with expert roof painting. Protective coatings, colour matched finishes, 10-year warranty. Serving SE Melbourne."
+        keywords="roof painting Melbourne, tile roof painting Melbourne, metal roof coatings, Call Kaids Roofing"
       />
       <StructuredData 
         type="service" 
         serviceName="Roof Painting"
         serviceDescription="Professional 3-day roof painting service with premium weather-resistant paint systems"
-        pageUrl="https://callkaidsroofing.com.au/services/roof-painting"
+        pageUrl="https://www.callkaidsroofing.com.au/services/roof-painting"
       />
       {/* Hero Section */}
       <section 

--- a/src/pages/services/RoofRepairs.tsx
+++ b/src/pages/services/RoofRepairs.tsx
@@ -72,17 +72,16 @@ const RoofRepairs = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead 
-        title="Emergency Roof Repairs Melbourne | Same Day Response | 24/7 Service"
-        description="Emergency roof repair Melbourne. Same-day response for leaks & storm damage. Available 24/7 across Southeast Melbourne. Call 0435 900 709"
-        keywords="emergency roof repairs Melbourne, roof leak repairs, storm damage repairs, 24/7 roof repairs Melbourne, urgent roof repairs"
-        canonical="https://callkaidsroofing.com.au/services/roof-repairs"
+      <SEOHead
+        title="Emergency Roof Repairs Melbourne | Same Day Response"
+        description="Emergency roof repair specialists serving Clyde North, Cranbourne, Berwick & SE Melbourne. Same-day leak control, storm damage repairs & 24/7 call-outs."
+        keywords="emergency roof repairs Melbourne, roof leak repairs Clyde North, storm damage repairs Berwick"
       />
       <StructuredData 
         type="service" 
         serviceName="Emergency Roof Repairs"
         serviceDescription="Same-day emergency response for active leaks, storm damage, and urgent roof repairs"
-        pageUrl="https://callkaidsroofing.com.au/services/roof-repairs"
+        pageUrl="https://www.callkaidsroofing.com.au/services/roof-repairs"
       />
       {/* Hero Section */}
       <section 

--- a/src/pages/services/RoofRepointing.tsx
+++ b/src/pages/services/RoofRepointing.tsx
@@ -29,7 +29,7 @@ const RoofRepointing = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Repointing",
-    "url": "https://callkaidsroofing.com.au/roof-repointing"
+    "url": "https://www.callkaidsroofing.com.au/roof-repointing"
   };
 
   return (
@@ -38,7 +38,6 @@ const RoofRepointing = () => {
         title="Roof Repointing Melbourne | Ridge Cap & Mortar Repair | Call Kaids Roofing"
         description="Professional roof repointing in Southeast Melbourne. Fix cracked mortar, stop leaks, and extend your roof's life. 10-year warranty. Call 0435 900 709."
         keywords="roof repointing Melbourne, ridge cap repair, mortar repair, roof pointing, Clyde North repointing, Southeast Melbourne roofing"
-        canonical="https://callkaidsroofing.com.au/roof-repointing"
         structuredData={structuredData}
       />
 

--- a/src/pages/services/RoofRestoration.tsx
+++ b/src/pages/services/RoofRestoration.tsx
@@ -101,17 +101,16 @@ const RoofRestoration = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead 
-        title="Roof Restoration Melbourne | Complete Roof Overhaul | 10 Year Warranty"
-        description="Professional roof restoration in Melbourne. Complete cleaning, repairs & premium coating. Transform your roof for 60% less than replacement. Call 0435 900 709"
-        keywords="roof restoration Melbourne, roof restoration Clyde North, roof restoration Berwick, complete roof overhaul Melbourne, roof membrane coating"
-        canonical="https://callkaidsroofing.com.au/services/roof-restoration"
+      <SEOHead
+        title="Roof Restorations Clyde North | Call Kaids Roofing SE Melbourne"
+        description="Bring your roof back to life with professional restorations. Serving Clyde North, Cranbourne, Berwick & surrounds. Honest quotes, lasting results."
+        keywords="roof restoration Clyde North, roof restoration Cranbourne, roof restoration Berwick, Call Kaids Roofing"
       />
       <StructuredData 
         type="service" 
         serviceName="Roof Restoration"
         serviceDescription="Complete roof overhaul with high-pressure clean, repairs, and premium membrane coating system"
-        pageUrl="https://callkaidsroofing.com.au/services/roof-restoration"
+        pageUrl="https://www.callkaidsroofing.com.au/services/roof-restoration"
       />
       {/* Hero Section */}
       <OptimizedBackgroundSection

--- a/src/pages/services/TileReplacement.tsx
+++ b/src/pages/services/TileReplacement.tsx
@@ -29,7 +29,7 @@ const TileReplacement = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Tile Replacement",
-    "url": "https://callkaidsroofing.com.au/tile-replacement"
+    "url": "https://www.callkaidsroofing.com.au/tile-replacement"
   };
 
   return (
@@ -38,7 +38,6 @@ const TileReplacement = () => {
         title="Broken Roof Tile Replacement Melbourne | Call Kaids Roofing"
         description="Professional broken roof tile replacement in Southeast Melbourne. Match existing tiles, prevent leaks. 10-year warranty. Call 0435 900 709."
         keywords="roof tile replacement Melbourne, broken tile repair, tile matching, roof leak repair, Clyde North tile replacement"
-        canonical="https://callkaidsroofing.com.au/tile-replacement"
         structuredData={structuredData}
       />
 

--- a/src/pages/services/suburbs/RoofPaintingClydeNorth.tsx
+++ b/src/pages/services/suburbs/RoofPaintingClydeNorth.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Brush, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofPaintingClydeNorth = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Painting Clyde North | Tile & Metal Roof Coatings"
+        description="Clyde North roof painting with premium membranes, fast turnaround and 10-year warranty. Freshen new estates or revive original builds."
+        keywords="roof painting Clyde North, roof coating Clyde North, tile roof painting Clyde North"
+      />
+
+      <section className="py-16 bg-primary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Painting in Clyde North
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Clyde North developments move fast, and keeping your roof sharp helps your home stand out. UV exposure, estate dust and new construction grime can dull tiles quickly. Our Clyde North roof painting service brings back that display-home finish.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            Whether you’re in Selandra Rise, Highgrove or Clydevale, we handle the colour consultation, roof prep and coating so everything looks flawless. We schedule work around school traffic and estate guidelines for a smooth experience.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Painting System</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'Roof cleaning & sterilising to remove builder dust and grime',
+              'Minor roof repairs to ensure a tight finish before coatings go on',
+              'Primer tailored to modern concrete tiles used across Clyde North estates',
+              'Two top coats with 10-year warranty in your preferred gloss level',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Recent Clyde North Roof Painting Transformations</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/e613c84a-7f19-4752-a2cb-836de3466396.png"
+              alt="Clyde North roof before painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/7c4b0aaa-18ed-4b8a-80f2-904dc4868236.png"
+              alt="Clyde North roof mid painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/992cf8cb-032a-4253-b9d7-45f675e69217.png"
+              alt="Clyde North roof after painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Clyde North Residents Choose Us</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Clyde North roof painting specialist who understands estate design rules.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 plus manufacturer guarantees.</p>
+              <p>• Phone: 0435 900 709 – talk directly with Kaidyn about colour samples and scheduling.</p>
+              <p>• Clean site management to keep driveways, render and landscaping spotless.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Clyde North Colour Ideas</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Monument, Night Sky and Basalt for bold contrast</li>
+                <li>✔ Shale Grey and Surfmist for bright architectural looks</li>
+                <li>✔ Woodland Grey and Dune for warm, earthy tones</li>
+                <li>✔ Custom tinting available to match render or garage doors</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Clyde North Roof Painting Quote</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Want that display-home shine back? Call today or book online for a detailed roof painting proposal in Clyde North.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofPaintingClydeNorth;

--- a/src/pages/services/suburbs/RoofPaintingCranbourne.tsx
+++ b/src/pages/services/suburbs/RoofPaintingCranbourne.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, PaintRoller, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofPaintingCranbourne = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Painting Cranbourne | Tile & Metal Roof Coatings"
+        description="Cranbourne roof painting specialists delivering sharp finishes, protective membranes and 10-year warranties. Colour matched to your suburb."
+        keywords="roof painting Cranbourne, roof coating Cranbourne, tile roof painting Cranbourne"
+      />
+
+      <section className="py-16 bg-secondary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-secondary">
+            Roof Painting in Cranbourne
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Cranbourne’s tree cover and humidity can leave roofs looking tired quickly. We specialise in roof painting for Cranbourne West, North and East, combining deep cleaning, roof repairs and premium coatings that stand up to the suburb’s heavy rainfalls.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            Whether you’re updating an investment property or freshening the family home, our Cranbourne roof painting service gives you crisp kerb appeal and long-term protection. We use membranes that resist algae and keep colour rich even under gum tree shade.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Painting System</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'Roof cleaning & biocide treatment to remove gum tree sap and staining',
+              'Tile and sheet repairs to ensure a smooth base coat',
+              'Primer designed for Cranbourne’s damp winters to avoid blistering',
+              'Dual-colour coats with 10-year warranty and anti-fungal additives',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-secondary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Recent Cranbourne Roof Painting Projects</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/5984413e-46ac-4f11-ac75-953d93235faa.png"
+              alt="Cranbourne roof before painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/58e47c2d-3b15-4aad-ae68-f09f4d0d421e.png"
+              alt="Cranbourne roof mid painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/324fc2cc-cf1b-4877-801b-846379d88b45.png"
+              alt="Cranbourne roof after painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Cranbourne Owners Trust Call Kaids Roofing</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Familiar with local colour palettes and estate requirements across Cranbourne.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 with membranes proven in wet climates.</p>
+              <p>• Phone: 0435 900 709 – direct line to Kaidyn for on-site colour comparisons.</p>
+              <p>• Careful masking and clean-up to protect gardens, driveways and neighbouring properties.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Cranbourne Colour Recommendations</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Monument, Basalt and Ironstone for modern estates</li>
+                <li>✔ Gully and Wallaby for warmer street appeal</li>
+                <li>✔ Surfmist for Hamptons-inspired renovations</li>
+                <li>✔ Custom colour matching available with gloss, satin or matte finishes</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-secondary text-secondary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Cranbourne Roof Painting Quote</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Ready to update your Cranbourne property? Call today or request a visit and we’ll bring colour swatches to your door.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-secondary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-secondary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofPaintingCranbourne;

--- a/src/pages/services/suburbs/RoofPaintingPakenham.tsx
+++ b/src/pages/services/suburbs/RoofPaintingPakenham.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Palette, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofPaintingPakenham = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Painting Pakenham | Tile & Metal Roof Coatings"
+        description="Transform your home’s look with expert roof painting. Protective coatings, colour matched finishes, 10-year warranty. Serving SE Melbourne."
+        keywords="roof painting Pakenham, roof coating Pakenham, tile roof painting Pakenham"
+      />
+
+      <section className="py-16 bg-primary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Painting in Pakenham
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Pakenham homes benefit massively from a fresh membrane. The mix of winter frost and hot afternoon sun fades roofs quickly along the Princes Highway corridor. Our Pakenham roof painting service renews colour, seals porous tiles and helps regulate roof temperatures.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            We prep every Pakenham roof thoroughly with pressure cleaning, repairs and primer to make sure the final coats bond. Choose from modern matte, satin or gloss finishes that suit Cardinia Lakes, Lakeside and heritage parts of town.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Painting System</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'Roof cleaning & sterilising to eliminate moss, lichen and farm dust',
+              'Tile repairs and pointing to create a solid base for coatings',
+              'Primer application tailored to concrete or terracotta tiles',
+              'Two-coat colour system with UV and hail resistance',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Recent Pakenham Roof Painting Results</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/0d5c8d43-0a56-42eb-a3fd-4ce0708040ce.png"
+              alt="Pakenham roof before painting"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/50cb1bd1-1166-4391-adc1-99c419346880.png"
+              alt="Base coat applied on Pakenham roof"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/5eea137e-7ec4-407d-8452-faeea24c872f.png"
+              alt="Pakenham roof after fresh paint"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Pakenham Chooses Call Kaids Roofing</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Local colour consultations to match Pakenham estates and planning guidelines.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 with Dulux or Shield Coat products.</p>
+              <p>• Phone: 0435 900 709 – Kaidyn assists with colour boards and sample swatches for Pakenham clients.</p>
+              <p>• Optional heat-reflective coatings to keep Pakenham homes cooler in summer.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Popular Pakenham Colour Options</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Basalt and Monument for modern estates</li>
+                <li>✔ Jasper and Woodland Grey for acreage properties</li>
+                <li>✔ Terracotta revival tones for traditional streets</li>
+                <li>✔ Custom colour matching available with gloss, satin or matte</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Pakenham Roof Colour Consultation</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Ready for a Pakenham roof refresh? Call today or request a visit to review colour samples in person.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofPaintingPakenham;

--- a/src/pages/services/suburbs/RoofRestorationBerwick.tsx
+++ b/src/pages/services/suburbs/RoofRestorationBerwick.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofRestorationBerwick = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Restorations Berwick | Call Kaids Roofing SE Melbourne"
+        description="High-end roof restoration for Berwick’s heritage homes and modern estates. Precision repairs, colour matched coatings and respectful site management."
+        keywords="roof restoration Berwick, heritage roof repair Berwick, roof coating Berwick"
+      />
+
+      <section className="py-16 bg-secondary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Restoration in Berwick
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Berwick’s leafy streets and heritage facades demand tidy rooflines. We restore established Berwick homes by respecting architectural details, matching tile profiles and working around tight driveways. From Brisbane Street character homes to modern Clyde Road builds, we tailor the restoration to the property.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            Berwick roofs often suffer from ridge cracking, flaking glaze and staining from towering gums. Our restoration approach blends careful cleaning, tile repairs and modern membrane systems so your Berwick property keeps its street appeal while staying watertight for another decade.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Restoration Process</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'High-pressure cleaning with attention to delicate heritage flashings',
+              'Tile replacement & repairs using reclaimed tiles that match Berwick colourways',
+              'Rebedding & repointing ridge caps to eliminate cracks caused by tree movement',
+              'Protective coatings with 10-year warranty for premium finishes and kerb appeal',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Before & After Transformations in Berwick</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/0362db50-69c4-4fd7-af15-a0112e09daeb.png"
+              alt="Berwick roof before restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/783444da-c25e-4910-89e1-1908a6296118.png"
+              alt="Berwick roof cleaning and repairs"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/5984413e-46ac-4f11-ac75-953d93235faa.png"
+              alt="Berwick roof after restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Berwick Homeowners Choose Us</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Berwick roof restoration specialists who work neatly on premium properties.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 and careful documentation for Berwick buyers.</p>
+              <p>• Phone: 0435 900 709 – direct access to Kaidyn to discuss colour options suited to Berwick Village.</p>
+              <p>• Respectful site management to protect driveways, gardens and heritage detailing.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Included with Every Berwick Restoration</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Detailed inspection of finials, valleys and flashings</li>
+                <li>✔ Colour matching to existing palettes or modern Dulux hues</li>
+                <li>✔ Ridge cap stabilization with flexible pointing compounds</li>
+                <li>✔ Gutter clean and debris removal after every visit</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Berwick Roof Health Check</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Keep your Berwick property looking premium. Call today or request an on-site roof assessment to plan your restoration properly.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofRestorationBerwick;

--- a/src/pages/services/suburbs/RoofRestorationClydeNorth.tsx
+++ b/src/pages/services/suburbs/RoofRestorationClydeNorth.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofRestorationClydeNorth = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Restorations Clyde North | Call Kaids Roofing SE Melbourne"
+        description="Bring your roof back to life with professional restorations. Serving Clyde North, Cranbourne, Berwick & surrounds. Honest quotes, lasting results."
+        keywords="roof restoration Clyde North, roof repair Clyde North, ridge cap repointing Clyde North"
+      />
+
+      <section className="py-16 bg-primary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Restoration in Clyde North
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Clyde North roofing cops a beating from the south-westerly winds that whip across the estate. Terracotta and concrete tiles fade fast from constant UV, and the early 2010s builds are now showing cracked ridge mortar. A tailored roof restoration keeps your Clyde North home watertight and sharp looking without tearing the roof off.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            I live fifteen minutes away, so I know how often the weather turns. Our Clyde North restoration package resets ridge caps, replaces brittle tiles and seals everything with a high-build membrane that holds colour and gloss. It is the quickest way to protect your investment as the suburb keeps growing.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Restoration Process</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'High-pressure cleaning to blast away moss and Clyde North road dust',
+              'Tile replacement & repairs using locally sourced spare tiles',
+              'Rebedding & repointing ridge caps with flexible pointing suited to estate winds',
+              'Protective coatings with 10-year warranty matched to modern Colorbond palettes',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Before & After Transformations in Clyde North</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/3a5f460c-0be2-45c5-9c92-e81b3da4f442.png"
+              alt="Clyde North roof before restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/468d2fb1-beac-44d1-a3b6-9b08217e6231.png"
+              alt="Clyde North roof cleaning in progress"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
+              alt="Clyde North roof after full restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Choose Call Kaids Roofing</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Local Clyde North roofing expert who understands the estates, covenants and soil movement issues.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 and full insurance.</p>
+              <p>• Phone: 0435 900 709 – you deal direct with me, Kaidyn, from first quote to final inspection.</p>
+              <p>• Flexible scheduling to work around Clyde North school runs and estate parking restrictions.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Included with Every Clyde North Restoration</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Detailed roof health report</li>
+                <li>✔ Drone photos before and after</li>
+                <li>✔ Gutter clean and valley iron inspection</li>
+                <li>✔ Colour consultation for modern neighbourhood palettes</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Get Your Free Roof Health Check</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Clyde North homeowners trust Call Kaids Roofing for straight answers and long-lasting roof restorations. Call us today or book a visit online.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofRestorationClydeNorth;

--- a/src/pages/services/suburbs/RoofRestorationCranbourne.tsx
+++ b/src/pages/services/suburbs/RoofRestorationCranbourne.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofRestorationCranbourne = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Restorations Cranbourne | Call Kaids Roofing SE Melbourne"
+        description="Cranbourne roof restoration specialists handling weathered tiles, moss build-up and storm wear. Local crew with 10-year workmanship warranty."
+        keywords="roof restoration Cranbourne, moss removal Cranbourne, roof repairs Cranbourne"
+      />
+
+      <section className="py-16 bg-secondary/5">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-secondary">
+            Roof Restoration in Cranbourne
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Cranbourne roofs cop humid mornings, tree debris and plenty of storm activity. The 80s and 90s homes in Cranbourne often suffer from porous tiles and pitted valleys. A custom roof restoration keeps Cranbourne houses looking sharp while sealing out persistent leaks.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            We flush gutters filled with tea-tree litter, reset ridge capping and apply a high-build membrane that stands up to Cranbourne’s temperature swings. Every project is planned around your schedule so you are never left with a half-finished roof when the next front blows through. 
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Restoration Process</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'High-pressure cleaning that removes years of Cranbourne moss and lichen',
+              'Tile replacement & repairs to cracked ridge corners and slipped valleys',
+              'Rebedding & repointing ridge caps to lock everything down before winter',
+              'Protective coatings with 10-year warranty and reflective pigments for hot summers',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-secondary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Before & After Transformations in Cranbourne</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/359deff0-4a4b-426d-acbc-993dfb3cb510.png"
+              alt="Cranbourne roof before restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/7c4b0aaa-18ed-4b8a-80f2-904dc4868236.png"
+              alt="Cranbourne roof restoration during cleaning"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png"
+              alt="Cranbourne roof after restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Cranbourne Homeowners Choose Us</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Cranbourne-based restoration crew familiar with local covenants and estate guidelines.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 and full insurance on every Cranbourne project.</p>
+              <p>• Phone: 0435 900 709 – speak directly with Kaidyn for advice on timing around Cranbourne’s weather.</p>
+              <p>• Detailed moisture checks for Cranbourne South, West and North properties where leaks commonly appear.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Included with Every Cranbourne Restoration</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Valley iron inspection and rust treatment</li>
+                <li>✔ Replacement of broken skylight flashings</li>
+                <li>✔ Flexible pointing on all ridge and hip junctions</li>
+                <li>✔ Complimentary gutter clean to handle heavy rains</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-secondary text-secondary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Cranbourne Roof Health Check</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Protect your Cranbourne home before the next storm season. Call today or request a visit online for a no-pressure roof assessment.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-secondary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-secondary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofRestorationCranbourne;

--- a/src/pages/services/suburbs/RoofRestorationMountEliza.tsx
+++ b/src/pages/services/suburbs/RoofRestorationMountEliza.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofRestorationMountEliza = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Restorations Mount Eliza | Call Kaids Roofing SE Melbourne"
+        description="Coastal roof restoration for Mount Eliza homes facing salt spray and bay winds. Premium coatings, meticulous repairs and 10-year warranties."
+        keywords="roof restoration Mount Eliza, coastal roof repair Mount Eliza, roof coating Mount Eliza"
+      />
+
+      <section className="py-16 bg-blue-50">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Restoration in Mount Eliza
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Mount Eliza roofs contend with salt spray, bay gusts and leafy surrounds. Coastal conditions chew through cheap coatings fast and corrode valley irons. Our Mount Eliza roof restorations reinforce your home against the elements while keeping that polished Mornington Peninsula presentation.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            From Canadian Bay Road to Mount Eliza Village, we work around steep driveways and curated gardens. Expect careful cleaning, ridge repairs and marine-grade membrane systems that resist salt, UV and moisture for the long haul.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Restoration Process</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'High-pressure cleaning to remove salt crystals, leaf stains and mould',
+              'Tile replacement & repairs with premium terracotta and concrete matches',
+              'Rebedding & repointing ridge caps to withstand coastal wind uplift',
+              'Protective coatings with 10-year warranty engineered for seaside exposure',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Before & After Transformations in Mount Eliza</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/7b53e2bb-e419-483c-b48c-ea2d1f5c139e.png"
+              alt="Mount Eliza roof before restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/116450ad-e39b-42bd-891b-c7e312d4cf91.png"
+              alt="Mount Eliza roof being restored"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/dfb36f59-24c0-44d0-8049-9677f7a3f7ba.png"
+              alt="Mount Eliza roof after restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Mount Eliza Homeowners Choose Us</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Mount Eliza roof restoration team familiar with coastal access and steep blocks.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 plus marine-grade product warranties.</p>
+              <p>• Phone: 0435 900 709 – Kaidyn coordinates personally to protect landscaping and scheduling.</p>
+              <p>• Detailed clean-up to keep your Mount Eliza property looking pristine for open homes.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Included with Every Mount Eliza Restoration</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Salt-resistant primers and membranes</li>
+                <li>✔ Flashing upgrades for bay-facing elevations</li>
+                <li>✔ Ridge tie-down checks for high-wind zones</li>
+                <li>✔ Full site clean-up including driveway wash-down</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Schedule Your Mount Eliza Roof Health Check</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Protect your Mount Eliza investment against salt and wind. Call today or book a premium roof inspection online.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofRestorationMountEliza;

--- a/src/pages/services/suburbs/RoofRestorationPakenham.tsx
+++ b/src/pages/services/suburbs/RoofRestorationPakenham.tsx
@@ -1,0 +1,124 @@
+import { SEOHead } from '@/components/SEOHead';
+import { Button } from '@/components/ui/button';
+import { OptimizedImage } from '@/components/OptimizedImage';
+import { CheckCircle, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const RoofRestorationPakenham = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Roof Restorations Pakenham | Call Kaids Roofing SE Melbourne"
+        description="Restore weathered Pakenham roofs with cleaning, repairs and membrane coatings designed for the hills and winter frost. Local crew, honest pricing."
+        keywords="roof restoration Pakenham, roof repair Pakenham, membrane coating Pakenham"
+      />
+
+      <section className="py-16 bg-accent/20">
+        <div className="container mx-auto px-4">
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-primary">
+            Roof Restoration in Pakenham
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground mb-4 max-w-3xl">
+            Pakenham rooftops handle frosty mornings, strong afternoon sun and the occasional hailstorm rolling off the ranges. The older estates in Pakenham are showing tile delamination and worn ridge mortar. A tailored roof restoration gives Pakenham homes a new lease on life while sealing out winter moisture.
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl">
+            We focus on dense cleaning, tile swaps and triple-coat membranes that shrug off UV and frost alike. Being regularly in Pakenham means we know the estate layouts and can source matching tiles quickly when replacements are needed.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Our Roof Restoration Process</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {[
+              'High-pressure cleaning to remove lichen and dairy dust common around Pakenham',
+              'Tile replacement & repairs for cracked hips and valleys from thermal movement',
+              'Rebedding & repointing ridge caps with flexible compounds that hold through cold snaps',
+              'Protective coatings with 10-year warranty to lock in colour on sloped Pakenham roofs',
+            ].map((item) => (
+              <div key={item} className="flex items-start gap-3 bg-card border rounded-lg p-4 shadow-sm">
+                <CheckCircle className="h-5 w-5 text-primary mt-1" />
+                <p className="text-muted-foreground">{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-muted/40">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Before & After Transformations in Pakenham</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <OptimizedImage
+              src="/lovable-uploads/3eea8208-16ab-4e73-8295-c92c3bf95f58.png"
+              alt="Pakenham roof before restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/5eea137e-7ec4-407d-8452-faeea24c872f.png"
+              alt="Mid restoration cleaning in Pakenham"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+            <OptimizedImage
+              src="/lovable-uploads/b583ddb3-be15-4d62-b3fe-1d5a4ed4cd2a.png"
+              alt="Pakenham roof after restoration"
+              className="rounded-lg"
+              width={600}
+              height={400}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-semibold mb-6">Why Pakenham Homeowners Choose Us</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="space-y-4 text-muted-foreground">
+              <p>• Pakenham roof restoration experts who understand hillside access challenges.</p>
+              <p>• 10-year workmanship warranty backed by ABN 39475055075 and comprehensive insurance for every Pakenham project.</p>
+              <p>• Phone: 0435 900 709 – speak directly with Kaidyn about booking around school traffic on the Princes Highway.</p>
+              <p>• Advice on colour schemes that complement Pakenham’s modern estates and heritage pockets.</p>
+            </div>
+            <div className="bg-card border rounded-lg p-6 shadow-sm">
+              <h3 className="text-xl font-semibold mb-4">Included with Every Pakenham Restoration</h3>
+              <ul className="space-y-2 text-muted-foreground">
+                <li>✔ Ridge cap inspection across every hip and valley</li>
+                <li>✔ Replacement valley irons where corrosion has started</li>
+                <li>✔ Dulux Acratex or Shield Coat membrane matched to local palettes</li>
+                <li>✔ Gutter clean and downpipe flush to prep for winter rains</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-primary text-primary-foreground">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <h2 className="text-3xl font-bold">Book Your Pakenham Roof Health Check</h2>
+          <p className="text-lg max-w-2xl mx-auto">
+            Keep your Pakenham property protected from frost, hail and summer heat. Call today or request an inspection online.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Button asChild size="lg" className="bg-white text-primary hover:bg-white/90">
+              <a href="tel:0435900709" className="flex items-center gap-2">
+                <Phone className="h-5 w-5" />
+                Call 0435 900 709
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-white text-white hover:bg-white hover:text-primary">
+              <Link to="/contact">Book Online</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default RoofRestorationPakenham;


### PR DESCRIPTION
## Summary
- enforce the www.callkaidsroofing.com.au canonical domain in metadata, structured data, and analytics helpers while updating robots, sitemap and default SEO copy
- add dedicated Clyde North, Cranbourne, Pakenham, Berwick and Mount Eliza roof restoration pages plus Clyde North, Cranbourne and Pakenham roof painting pages, wiring them into the router
- improve UX with a sticky mobile call button and align existing service pages with the new metadata strategy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c972dd7fac8320b02487c14f7bdd08