### PR TITLE
Fix canonical domain redirect to prevent SSL mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="canonical" href="https://www.callkaidsroofing.com.au/" />
+    <link rel="canonical" href="https://callkaidsroofing.com.au/" />
     <title>Call Kaids Roofing | Roof Restorations Clyde North &amp; SE Melbourne</title>
     <meta name="description" content="Local roofing experts in Clyde North. Roof restorations, painting, repairs &amp; gutter cleaning with 10-year warranty. Call 0435 900 709 today." />
 
@@ -15,18 +15,17 @@
     />
     
     <script>
-      (function enforceCanonicalDomain() {
-        var canonicalHost = "www.callkaidsroofing.com.au";
-        var bareHost = "callkaidsroofing.com.au";
+      (function enforceSecureProtocol() {
+        var primaryHosts = ["callkaidsroofing.com.au", "www.callkaidsroofing.com.au"];
         if (typeof window === "undefined") return;
         var hostname = window.location.hostname;
         var protocol = window.location.protocol;
-        // Only enforce when visiting our actual domain(s). Allow previews and other hosts.
-        if (hostname !== canonicalHost && hostname !== bareHost) {
+        // Only enforce when visiting our production domains. Allow previews and other hosts.
+        if (primaryHosts.indexOf(hostname) === -1) {
           return;
         }
-        if (hostname !== canonicalHost || protocol !== "https:") {
-          var newUrl = "https://" + canonicalHost + window.location.pathname + window.location.search + window.location.hash;
+        if (protocol !== "https:") {
+          var newUrl = "https://" + window.location.host + window.location.pathname + window.location.search + window.location.hash;
           window.location.replace(newUrl);
         }
       })();
@@ -74,8 +73,8 @@
     <meta property="og:title" content="Call Kaids Roofing | Professional Roof Services Melbourne" />
     <meta property="og:description" content="Professional roofing services in Melbourne. Roof restoration, painting, emergency repairs with 10-year warranty. Call 0435 900 709." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.callkaidsroofing.com.au/" />
-    <meta property="og:image" content="https://www.callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
+    <meta property="og:url" content="https://callkaidsroofing.com.au/" />
+    <meta property="og:image" content="https://callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
     <meta property="og:locale" content="en_AU" />
     <meta property="og:site_name" content="Call Kaids Roofing" />
 
@@ -83,7 +82,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Call Kaids Roofing | Professional Roof Services Melbourne" />
     <meta name="twitter:description" content="Professional roofing services with 10-year warranty. Serving Melbourne SE suburbs." />
-    <meta name="twitter:image" content="https://www.callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
+    <meta name="twitter:image" content="https://callkaidsroofing.com.au/lovable-uploads/884e66b0-35da-491d-b03b-d980d46b3043.png" />
     <meta name="twitter:site" content="@callkaidsroofing" />
     <meta name="twitter:creator" content="@callkaidsroofing" />
     
@@ -100,7 +99,7 @@
       "@type": "RoofingContractor",
       "name": "Call Kaids Roofing",
       "description": "Professional roofing services across Southeast Melbourne. Roof restoration, painting, emergency repairs with 10-year workmanship warranty.",
-      "url": "https://www.callkaidsroofing.com.au",
+      "url": "https://callkaidsroofing.com.au",
       "telephone": "+61 435 900 709",
       "email": "callkaidsroofing@outlook.com",
       "address": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -16,7 +16,7 @@ Disallow: /admin/
 Disallow: /private/
 
 # Sitemaps
-Sitemap: https://www.callkaidsroofing.com.au/sitemap.xml
+Sitemap: https://callkaidsroofing.com.au/sitemap.xml
 
 # Crawl delay for respectful crawling
 Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,151 +1,151 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.callkaidsroofing.com.au/</loc>
+    <loc>https://callkaidsroofing.com.au/</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/about</loc>
+    <loc>https://callkaidsroofing.com.au/about</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/contact</loc>
+    <loc>https://callkaidsroofing.com.au/contact</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/gallery</loc>
+    <loc>https://callkaidsroofing.com.au/gallery</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/blog</loc>
+    <loc>https://callkaidsroofing.com.au/blog</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.65</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/emergency</loc>
+    <loc>https://callkaidsroofing.com.au/emergency</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/warranty</loc>
+    <loc>https://callkaidsroofing.com.au/warranty</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.60</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/privacy-policy</loc>
+    <loc>https://callkaidsroofing.com.au/privacy-policy</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.40</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.95</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-clyde-north</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration-clyde-north</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.90</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-cranbourne</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration-cranbourne</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-pakenham</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration-pakenham</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-berwick</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration-berwick</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-restoration-mount-eliza</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration-mount-eliza</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-painting</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-painting</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.92</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-pakenham</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-painting-pakenham</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-cranbourne</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-painting-cranbourne</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-painting-clyde-north</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-painting-clyde-north</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.88</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-repairs</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-repairs</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.90</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/gutter-cleaning</loc>
+    <loc>https://callkaidsroofing.com.au/services/gutter-cleaning</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/valley-iron-replacement</loc>
+    <loc>https://callkaidsroofing.com.au/services/valley-iron-replacement</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/roof-repointing</loc>
+    <loc>https://callkaidsroofing.com.au/services/roof-repointing</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/tile-replacement</loc>
+    <loc>https://callkaidsroofing.com.au/services/tile-replacement</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/services/leak-detection</loc>
+    <loc>https://callkaidsroofing.com.au/services/leak-detection</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.70</priority>
   </url>
   <url>
-    <loc>https://www.callkaidsroofing.com.au/book</loc>
+    <loc>https://callkaidsroofing.com.au/book</loc>
     <lastmod>2024-02-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.60</priority>

--- a/src/components/LocalBusinessSchema.tsx
+++ b/src/components/LocalBusinessSchema.tsx
@@ -14,20 +14,20 @@ export const LocalBusinessSchema = ({
   const baseSchema: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
-    "@id": "https://www.callkaidsroofing.com.au/#organization",
+    "@id": "https://callkaidsroofing.com.au/#organization",
     name: "Call Kaids Roofing",
     alternateName: "Kaids Roofing",
     description: `Professional roofing services in ${suburb || 'Southeast Melbourne'} specializing in ${serviceType || 'roof restoration, painting and emergency repairs'}`,
-    url: "https://www.callkaidsroofing.com.au",
+    url: "https://callkaidsroofing.com.au",
     logo: {
       "@type": "ImageObject",
-      url: "https://www.callkaidsroofing.com.au/logo.png",
+      url: "https://callkaidsroofing.com.au/logo.png",
       width: 300,
       height: 200
     },
     image: {
       "@type": "ImageObject",
-      url: "https://www.callkaidsroofing.com.au/og-image.jpg",
+      url: "https://callkaidsroofing.com.au/og-image.jpg",
       width: 1200,
       height: 630
     },
@@ -139,23 +139,23 @@ export const LocalBusinessSchema = ({
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: "https://www.callkaidsroofing.com.au/"
+        item: "https://callkaidsroofing.com.au/"
       },
       ...(serviceType ? [{
         "@type": "ListItem",
         position: 2,
         name: "Services",
-        item: "https://www.callkaidsroofing.com.au/services"
+        item: "https://callkaidsroofing.com.au/services"
       }, {
         "@type": "ListItem",
         position: 3,
         name: serviceType,
-        item: `https://www.callkaidsroofing.com.au/services/${serviceType.toLowerCase().replace(/\s+/g, '-')}`
+        item: `https://callkaidsroofing.com.au/services/${serviceType.toLowerCase().replace(/\s+/g, '-')}`
       }] : pageName !== "Home" ? [{
         "@type": "ListItem",
         position: 2,
         name: pageName,
-        item: `https://www.callkaidsroofing.com.au/${pageName.toLowerCase()}`
+        item: `https://callkaidsroofing.com.au/${pageName.toLowerCase()}`
       }] : [])
     ]
   };

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -15,18 +15,18 @@ export const SEOHead = ({
   description = "Local roofing experts in Clyde North. Roof restorations, painting, repairs & gutter cleaning with 10-year warranty. Call 0435 900 709 today.",
   keywords = "roof restoration Clyde North, roof painting Clyde North, roof repairs Southeast Melbourne, local roofing contractor, Call Kaids Roofing",
   canonical,
-  ogImage = "https://www.callkaidsroofing.com.au/og-image.jpg",
+  ogImage = "https://callkaidsroofing.com.au/og-image.jpg",
   structuredData
 }: SEOHeadProps) => {
   const location = useLocation();
 
-  const canonicalUrl = canonical || `https://www.callkaidsroofing.com.au${location.pathname}${location.search}`;
+  const canonicalUrl = canonical || `https://callkaidsroofing.com.au${location.pathname}${location.search}`;
 
   const defaultStructured = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
     name: "Call Kaids Roofing",
-    url: "https://www.callkaidsroofing.com.au",
+    url: "https://callkaidsroofing.com.au",
     telephone: "+61-435-900-709",
     email: "callkaidsroofing@outlook.com",
     address: {

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -17,21 +17,21 @@ export const StructuredData = ({
   const organizationSchema = {
     "@context": "https://schema.org",
     "@type": "RoofingContractor",
-    "@id": "https://www.callkaidsroofing.com.au/#organization",
+    "@id": "https://callkaidsroofing.com.au/#organization",
     name: "Call Kaids Roofing",
     legalName: "Call Kaids Roofing",
     alternateName: ["Kaids Roofing", "Call Kaids"],
     description: "Professional roofing services in Southeast Melbourne specializing in roof restoration, painting, and emergency repairs with 10-year warranty.",
-    url: "https://www.callkaidsroofing.com.au",
+    url: "https://callkaidsroofing.com.au",
     logo: {
       "@type": "ImageObject",
-      url: "https://www.callkaidsroofing.com.au/logo.png",
+      url: "https://callkaidsroofing.com.au/logo.png",
       width: "300",
       height: "100"
     },
     image: [
-      "https://www.callkaidsroofing.com.au/og-image.jpg",
-      "https://www.callkaidsroofing.com.au/assets/hero-roof-restoration.jpg"
+      "https://callkaidsroofing.com.au/og-image.jpg",
+      "https://callkaidsroofing.com.au/assets/hero-roof-restoration.jpg"
     ],
     telephone: "+61-435-900-709",
     email: "callkaidsroofing@outlook.com",
@@ -103,11 +103,11 @@ export const StructuredData = ({
           "@type": "Offer",
           itemOffered: {
             "@type": "Service",
-            "@id": "https://www.callkaidsroofing.com.au/services/roof-restoration",
+            "@id": "https://callkaidsroofing.com.au/services/roof-restoration",
             name: "Roof Restoration Melbourne",
             description: "Complete roof restoration including high-pressure cleaning, repairs, and premium membrane coating with 10-year warranty.",
-            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$6,000 - $30,000",
@@ -119,11 +119,11 @@ export const StructuredData = ({
           "@type": "Offer", 
           itemOffered: {
             "@type": "Service",
-            "@id": "https://www.callkaidsroofing.com.au/services/roof-painting",
+            "@id": "https://callkaidsroofing.com.au/services/roof-painting",
             name: "Roof Painting Melbourne",
             description: "Professional roof painting with premium weather-resistant paints, completed in 2-3 days with 10-year warranty.",
-            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$4,000 - $18,000",
@@ -135,11 +135,11 @@ export const StructuredData = ({
           "@type": "Offer",
           itemOffered: {
             "@type": "Service", 
-            "@id": "https://www.callkaidsroofing.com.au/services/roof-repairs",
+            "@id": "https://callkaidsroofing.com.au/services/roof-repairs",
             name: "Emergency Roof Repairs Melbourne",
             description: "24/7 emergency roof repair services for leaks, storm damage, and urgent roofing issues across Southeast Melbourne.",
-            provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
-            areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
+            provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
+            areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
             offers: {
               "@type": "Offer",
               priceRange: "$150 - $2,000",
@@ -210,18 +210,18 @@ export const StructuredData = ({
         "@type": "ListItem",
         position: 1,
         name: "Home",
-        item: "https://www.callkaidsroofing.com.au/"
+        item: "https://callkaidsroofing.com.au/"
       },
       ...(type === 'service' && serviceName ? [{
         "@type": "ListItem",
         position: 2,
         name: "Services",
-        item: "https://www.callkaidsroofing.com.au/services"
+        item: "https://callkaidsroofing.com.au/services"
       }, {
         "@type": "ListItem",
         position: 3,
         name: serviceName,
-        item: pageUrl || `https://www.callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`
+        item: pageUrl || `https://callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`
       }] : [])
     ]
   };
@@ -229,11 +229,11 @@ export const StructuredData = ({
   const serviceSchema = serviceName ? {
     "@context": "https://schema.org",
     "@type": "Service",
-    "@id": pageUrl || `https://www.callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`,
+    "@id": pageUrl || `https://callkaidsroofing.com.au/services/${serviceName.toLowerCase().replace(/\s+/g, '-')}`,
     name: serviceName,
     description: serviceDescription || `Professional ${serviceName.toLowerCase()} services in Southeast Melbourne by Call Kaids Roofing.`,
-    provider: { "@id": "https://www.callkaidsroofing.com.au/#organization" },
-    areaServed: { "@id": "https://www.callkaidsroofing.com.au/#servicearea" },
+    provider: { "@id": "https://callkaidsroofing.com.au/#organization" },
+    areaServed: { "@id": "https://callkaidsroofing.com.au/#servicearea" },
     category: "Roofing Services",
     hasOfferCatalog: {
       "@type": "OfferCatalog",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -61,7 +61,7 @@ const Index = () => {
         title="Call Kaids Roofing | Roof Restorations Clyde North & SE Melbourne"
         description="Local roofing experts in Clyde North. Roof restorations, painting, repairs & gutter cleaning with 10-year warranty. Call 0435 900 709 today."
         keywords="roof restorations Clyde North, roof painting southeast Melbourne, gutter cleaning Clyde North, roof repairs Berwick"
-        ogImage="https://www.callkaidsroofing.com.au/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
+        ogImage="https://callkaidsroofing.com.au/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
       />
       <StructuredData type="homepage" />
       <div className="page-transition">

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -22,7 +22,7 @@ export default function PrivacyPolicy() {
                 <h2 className="text-2xl font-semibold text-foreground mb-4">Who We Are</h2>
                 <p>
                   Call Kaids Roofing (ABN: 39475055075) is a roofing contractor based in Clyde North, Victoria. 
-                  Our website address is: https://www.callkaidsroofing.com.au
+                  Our website address is: https://callkaidsroofing.com.au
                 </p>
               </section>
 

--- a/src/pages/services/LeakDetection.tsx
+++ b/src/pages/services/LeakDetection.tsx
@@ -29,7 +29,7 @@ const LeakDetection = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Leak Detection",
-    "url": "https://www.callkaidsroofing.com.au/leak-detection"
+    "url": "https://callkaidsroofing.com.au/leak-detection"
   };
 
   return (

--- a/src/pages/services/RoofPainting.tsx
+++ b/src/pages/services/RoofPainting.tsx
@@ -101,7 +101,7 @@ const RoofPainting = () => {
         type="service" 
         serviceName="Roof Painting"
         serviceDescription="Professional 3-day roof painting service with premium weather-resistant paint systems"
-        pageUrl="https://www.callkaidsroofing.com.au/services/roof-painting"
+        pageUrl="https://callkaidsroofing.com.au/services/roof-painting"
       />
       {/* Hero Section */}
       <section 

--- a/src/pages/services/RoofRepairs.tsx
+++ b/src/pages/services/RoofRepairs.tsx
@@ -81,7 +81,7 @@ const RoofRepairs = () => {
         type="service" 
         serviceName="Emergency Roof Repairs"
         serviceDescription="Same-day emergency response for active leaks, storm damage, and urgent roof repairs"
-        pageUrl="https://www.callkaidsroofing.com.au/services/roof-repairs"
+        pageUrl="https://callkaidsroofing.com.au/services/roof-repairs"
       />
       {/* Hero Section */}
       <section 

--- a/src/pages/services/RoofRepointing.tsx
+++ b/src/pages/services/RoofRepointing.tsx
@@ -29,7 +29,7 @@ const RoofRepointing = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Repointing",
-    "url": "https://www.callkaidsroofing.com.au/roof-repointing"
+    "url": "https://callkaidsroofing.com.au/roof-repointing"
   };
 
   return (

--- a/src/pages/services/RoofRestoration.tsx
+++ b/src/pages/services/RoofRestoration.tsx
@@ -110,7 +110,7 @@ const RoofRestoration = () => {
         type="service" 
         serviceName="Roof Restoration"
         serviceDescription="Complete roof overhaul with high-pressure clean, repairs, and premium membrane coating system"
-        pageUrl="https://www.callkaidsroofing.com.au/services/roof-restoration"
+        pageUrl="https://callkaidsroofing.com.au/services/roof-restoration"
       />
       {/* Hero Section */}
       <OptimizedBackgroundSection

--- a/src/pages/services/TileReplacement.tsx
+++ b/src/pages/services/TileReplacement.tsx
@@ -29,7 +29,7 @@ const TileReplacement = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Tile Replacement",
-    "url": "https://www.callkaidsroofing.com.au/tile-replacement"
+    "url": "https://callkaidsroofing.com.au/tile-replacement"
   };
 
   return (


### PR DESCRIPTION
## Summary
- stop forcing the app to redirect users to the www subdomain and only enforce HTTPS for production hosts to avoid the SSL mismatch
- switch canonical links, structured data, and marketing metadata to the apex callkaidsroofing.com.au domain
- update sitemap and robots metadata so crawlers reference the working secure domain

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca79f5c3348320b78468a0260a7e19