### PR TITLE
Add sitemap and noindex meta tags on admin pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,6 +12,11 @@ Allow: /
 
 User-agent: *
 Allow: /
+Allow: /services/
+Allow: /about
+Allow: /contact
+Allow: /emergency
+Allow: /warranty
 Disallow: /admin/
 Disallow: /private/
 
@@ -20,14 +25,3 @@ Sitemap: https://callkaidsroofing.com.au/sitemap.xml
 
 # Crawl delay for respectful crawling
 Crawl-delay: 1
-
-# Allow access to important pages
-Allow: /services/
-Allow: /about
-Allow: /contact
-Allow: /emergency
-Allow: /warranty
-
-# Prevent indexing of admin or private areas (if any exist in future)
-Disallow: /admin/
-Disallow: /private/

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,152 +2,182 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://callkaidsroofing.com.au/</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.00</priority>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-painting-clyde-north</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-painting-cranbourne</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-painting-pakenham</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration-berwick</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration-clyde-north</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration-cranbourne</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration-mount-eliza</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration-pakenham</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/gutter-cleaning</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/leak-detection</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-painting</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-repairs</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-repointing</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/roof-restoration</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/tile-replacement</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/valley-iron-replacement</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/about</loc>
-    <lastmod>2024-02-15</lastmod>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.80</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/contact</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.80</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/gallery</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.70</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/blog</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.65</priority>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/blog-post</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/booking-page</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/contact</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/emergency</loc>
-    <lastmod>2024-02-15</lastmod>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.70</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/warranty</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.60</priority>
+    <loc>https://callkaidsroofing.com.au/gallery</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/landing-page</loc>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/privacy-policy</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.40</priority>
+    <lastmod>2025-09-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration</loc>
-    <lastmod>2024-02-15</lastmod>
+    <loc>https://callkaidsroofing.com.au/restoration-landing</loc>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.95</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration-clyde-north</loc>
-    <lastmod>2024-02-15</lastmod>
+    <loc>https://callkaidsroofing.com.au/services</loc>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.90</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration-cranbourne</loc>
-    <lastmod>2024-02-15</lastmod>
+    <loc>https://callkaidsroofing.com.au/thank-you</loc>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration-pakenham</loc>
-    <lastmod>2024-02-15</lastmod>
+    <loc>https://callkaidsroofing.com.au/warranty</loc>
+    <lastmod>2025-09-21</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration-berwick</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-restoration-mount-eliza</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.85</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-painting</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.92</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-painting-pakenham</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-painting-cranbourne</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-painting-clyde-north</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.88</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-repairs</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.90</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/gutter-cleaning</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/valley-iron-replacement</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/roof-repointing</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.70</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/tile-replacement</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.70</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services/leak-detection</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.70</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/book</loc>
-    <lastmod>2024-02-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.60</priority>
+    <priority>0.8</priority>
   </url>
 </urlset>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { supabase } from '@/integrations/supabase/client';
 import { FacebookSDK } from '@/components/FacebookSDK';
 import { SocialMediaManager } from '@/components/SocialMediaManager';
+import { Helmet } from 'react-helmet-async';
 
 import { 
   LogOut, 
@@ -167,39 +168,48 @@ const AdminDashboard = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-lg text-muted-foreground">Loading Call Kaids Admin Dashboard...</p>
+      <>
+        <Helmet>
+          <meta name="robots" content="noindex, nofollow" />
+        </Helmet>
+        <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+            <p className="text-lg text-muted-foreground">Loading Call Kaids Admin Dashboard...</p>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30">
-      {/* Header */}
-      <div className="bg-card/95 backdrop-blur-sm border-b shadow-lg">
-        <div className="container mx-auto px-4 py-6">
-          <div className="flex justify-between items-center">
-            <div>
-              <h1 className="text-3xl font-bold gradient-text">Call Kaids Roofing</h1>
-              <p className="text-muted-foreground text-lg">
-                Professional Roofing Management Dashboard
-              </p>
-              <p className="text-sm text-primary font-medium mt-1">
-                ABN: 39475055075 | Kaidyn Brownlie | Welcome, {user?.email}
-              </p>
+    <>
+      <Helmet>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+      <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30">
+        {/* Header */}
+        <div className="bg-card/95 backdrop-blur-sm border-b shadow-lg">
+          <div className="container mx-auto px-4 py-6">
+            <div className="flex justify-between items-center">
+              <div>
+                <h1 className="text-3xl font-bold gradient-text">Call Kaids Roofing</h1>
+                <p className="text-muted-foreground text-lg">
+                  Professional Roofing Management Dashboard
+                </p>
+                <p className="text-sm text-primary font-medium mt-1">
+                  ABN: 39475055075 | Kaidyn Brownlie | Welcome, {user?.email}
+                </p>
+              </div>
+              <Button onClick={handleLogout} variant="outline" size="lg" className="hover-lift">
+                <LogOut className="h-4 w-4 mr-2" />
+                Sign Out
+              </Button>
             </div>
-            <Button onClick={handleLogout} variant="outline" size="lg" className="hover-lift">
-              <LogOut className="h-4 w-4 mr-2" />
-              Sign Out
-            </Button>
           </div>
         </div>
-      </div>
 
-      <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto px-4 py-8">
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8 stagger-animation">
           <Card className="hover-lift roofing-shadow">
@@ -422,6 +432,7 @@ const AdminDashboard = () => {
         </Tabs>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/hooks/use-toast';
 import { Lock, Eye, EyeOff, UserPlus, ArrowLeft, LogIn, Shield } from 'lucide-react';
 import { useAuth } from '@/components/AuthProvider';
 import { supabase } from '@/integrations/supabase/client';
+import { Helmet } from 'react-helmet-async';
 
 const AdminLogin = () => {
   const [loginData, setLoginData] = useState({ email: '', password: '' });
@@ -128,17 +129,26 @@ const AdminLogin = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center">
-        <div className="text-lg text-muted-foreground">Loading Call Kaids Admin...</div>
-      </div>
+      <>
+        <Helmet>
+          <meta name="robots" content="noindex, nofollow" />
+        </Helmet>
+        <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center">
+          <div className="text-lg text-muted-foreground">Loading Call Kaids Admin...</div>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center px-4">
+    <>
+      <Helmet>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+      <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/10 to-muted/30 flex items-center justify-center px-4">
       {/* Back to Website Link */}
-      <Link 
-        to="/" 
+      <Link
+        to="/"
         className="absolute top-4 left-4 flex items-center gap-2 text-primary hover:text-primary/80 transition-colors font-medium"
       >
         <ArrowLeft className="h-4 w-4" />
@@ -310,7 +320,8 @@ const AdminLogin = () => {
           </div>
         </CardContent>
       </Card>
-    </div>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a public sitemap listing the primary marketing routes with metadata for search engines
- embed Helmet-driven noindex meta tags on the admin dashboard and login pages to block indexing
- align robots.txt to point to the sitemap and disallow admin/private paths for crawlers

## Testing
- npm install
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02b657fb48320a4929171c752629b