### PR TITLE
feat: refresh service pages and bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -73,6 +74,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^15.15.0",
+        "jsdom": "^27.0.0",
         "lovable-tagger": "^1.1.9",
         "postcss": "^8.5.6",
         "sharp": "^0.34.4",
@@ -95,6 +97,77 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.6.tgz",
+      "integrity": "sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
@@ -106,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -152,6 +225,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -3376,6 +3587,63 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -3931,6 +4199,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4019,6 +4297,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4072,6 +4361,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -4360,6 +4659,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4370,6 +4683,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/csstype": {
@@ -4499,6 +4827,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/date-fns": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
@@ -4527,6 +4906,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -4549,6 +4935,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.0",
@@ -4577,6 +4974,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4634,6 +5039,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -5198,6 +5616,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5329,6 +5801,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5376,6 +5855,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/json-buffer": {
@@ -5965,6 +6521,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -5974,6 +6541,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6183,6 +6757,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6431,6 +7018,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6755,6 +7391,16 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -6828,6 +7474,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6849,6 +7502,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7190,6 +7863,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -7389,6 +8069,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7399,6 +8099,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -7792,11 +8505,47 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -7958,6 +8707,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
@@ -80,6 +81,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^15.15.0",
+    "jsdom": "^27.0.0",
     "lovable-tagger": "^1.1.9",
     "postcss": "^8.5.6",
     "sharp": "^0.34.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,16 +22,21 @@ const RoofRestoration = lazy(() => import("./pages/services/RoofRestoration"));
 const RoofPainting = lazy(() => import("./pages/services/RoofPainting"));
 const RoofRepairs = lazy(() => import("./pages/services/RoofRepairs"));
 const GutterCleaning = lazy(() => import("./pages/services/GutterCleaning"));
+const RoofCleaning = lazy(() => import("./pages/services/RoofCleaning"));
 const ValleyIronReplacement = lazy(() => import("./pages/services/ValleyIronReplacement"));
 const RoofRepointing = lazy(() => import("./pages/services/RoofRepointing"));
 const TileReplacement = lazy(() => import("./pages/services/TileReplacement"));
 const LeakDetection = lazy(() => import("./pages/services/LeakDetection"));
+const ResarkingAndBattening = lazy(() => import("./pages/services/ResarkingAndBattening"));
+const ReroofAndExtensions = lazy(() => import("./pages/services/ReroofAndExtensions"));
+const HealthCheck = lazy(() => import("./pages/services/HealthCheck"));
 const LandingPage = lazy(() => import("./pages/LandingPage"));
 const BookingPage = lazy(() => import("./pages/BookingPage"));
 const Blog = lazy(() => import("./pages/Blog"));
 const BlogPost = lazy(() => import("./pages/BlogPost"));
 const ThankYou = lazy(() => import("./pages/ThankYou"));
 const Services = lazy(() => import("./pages/Services"));
+const Bundles = lazy(() => import("./pages/Bundles"));
 const AdminLogin = lazy(() => import("./pages/AdminLogin"));
 const AdminDashboard = lazy(() => import("./pages/AdminDashboard"));
 const RestorationLanding = lazy(() => import("./pages/RestorationLanding"));
@@ -103,15 +108,27 @@ function App() {
                     <Route path="services/roof-painting-clyde-north" element={<RoofPaintingClydeNorth />} />
                     <Route path="services/roof-repairs" element={<RoofRepairs />} />
                     <Route path="services/gutter-cleaning" element={<GutterCleaning />} />
+                    <Route path="services/roof-pressure-cleaning" element={<RoofCleaning />} />
                     <Route path="services/valley-iron-replacement" element={<ValleyIronReplacement />} />
                     <Route path="services/roof-repointing" element={<RoofRepointing />} />
+                    <Route path="services/leak-repairs" element={<RoofRepairs />} />
+                    <Route path="services/resarking-battening" element={<ResarkingAndBattening />} />
+                    <Route path="services/re-roof-extensions" element={<ReroofAndExtensions />} />
+                    <Route path="services/health-check" element={<HealthCheck />} />
                     <Route path="services/tile-replacement" element={<TileReplacement />} />
                     <Route path="services/leak-detection" element={<LeakDetection />} />
                     <Route path="roof-restoration" element={<RoofRestoration />} />
                     <Route path="roof-painting" element={<RoofPainting />} />
                     <Route path="roof-repointing" element={<RoofRepointing />} />
+                    <Route path="ridge-repointing" element={<RoofRepointing />} />
                     <Route path="tile-replacement" element={<TileReplacement />} />
                     <Route path="leak-detection" element={<LeakDetection />} />
+                    <Route path="leak-repairs" element={<RoofRepairs />} />
+                    <Route path="roof-pressure-cleaning" element={<RoofCleaning />} />
+                    <Route path="resarking-battening" element={<ResarkingAndBattening />} />
+                    <Route path="re-roof-extensions" element={<ReroofAndExtensions />} />
+                    <Route path="health-check" element={<HealthCheck />} />
+                    <Route path="bundles" element={<Bundles />} />
                     <Route path="emergency-landing" element={<LandingPage />} />
                     <Route path="landing/:source" element={<LandingPage />} />
                     <Route path="restoration-landing" element={<RestorationLanding />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { Phone, Menu, X, ChevronDown, Shield, MapPin } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
 import { OptimizedImage } from '@/components/OptimizedImage';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
 import wideLogo from '/lovable-uploads/8d1be6f1-c743-47df-8d3e-f1ab6230f326.png';
 
 const Header = () => {
@@ -11,14 +12,16 @@ const Header = () => {
   const [servicesDropdownOpen, setServicesDropdownOpen] = useState(false);
 
   const services = [
-    { name: 'Roof Restoration', href: '/services/roof-restoration' },
-    { name: 'Roof Painting', href: '/services/roof-painting' },
-    { name: 'Roof Repointing', href: '/services/roof-repointing' },
-    { name: 'Tile Replacement', href: '/services/tile-replacement' },
-    { name: 'Leak Detection', href: '/services/leak-detection' },
+    { name: 'Roof Restoration', href: '/roof-restoration' },
+    { name: 'Ridge Rebedding & Repointing', href: '/ridge-repointing' },
+    { name: 'Leak Repairs', href: '/leak-repairs' },
+    { name: 'Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
     { name: 'Gutter Cleaning', href: '/services/gutter-cleaning' },
     { name: 'Valley Iron Replacement', href: '/services/valley-iron-replacement' },
-    { name: 'Roof Repairs', href: '/services/roof-repairs' },
+    { name: 'Resarking & Battening', href: '/services/resarking-battening' },
+    { name: 'Re-roof & Extensions', href: '/services/re-roof-extensions' },
+    { name: 'Free Roof Health Check', href: '/services/health-check' },
+    { name: 'Bundle Deals', href: '/bundles' }
   ];
 
   return (
@@ -118,9 +121,9 @@ const Header = () => {
           <div className="hidden md:flex items-center space-x-4">
             <div className="text-right">
               <div className="text-xs text-muted-foreground">Call Kaidyn Directly</div>
-              <a href="tel:0435900709" className="flex items-center space-x-2 text-primary hover:text-primary/80 transition-colors">
+              <a href={COMPANY_PHONE_TEL} className="flex items-center space-x-2 text-primary hover:text-primary/80 transition-colors">
                 <Phone className="h-4 w-4" />
-                <span className="font-bold text-lg">0435 900 709</span>
+                <span className="font-bold text-lg">{COMPANY_PHONE_DISPLAY}</span>
               </a>
             </div>
             <div className="h-8 w-px bg-border"></div>
@@ -215,9 +218,9 @@ const Header = () => {
               
               {/* Mobile Phone & CTA */}
               <div className="px-3 py-4 space-y-3 border-t">
-                <a href="tel:0435900709" className="flex items-center justify-center space-x-2 text-primary font-semibold">
+                <a href={COMPANY_PHONE_TEL} className="flex items-center justify-center space-x-2 text-primary font-semibold">
                   <Phone className="h-5 w-5" />
-                  <span>0435 900 709</span>
+                  <span>{COMPANY_PHONE_DISPLAY}</span>
                 </a>
                 <Button asChild variant="premium" size="lg" className="w-full">
                   <Link to="/book" onClick={() => setMobileMenuOpen(false)}>Get Quote</Link>

--- a/src/components/services/__tests__/service-ctas.test.tsx
+++ b/src/components/services/__tests__/service-ctas.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ServiceCtas } from '@/components/services/service-ctas';
+import type { ServiceCta } from '@/components/services/service-ctas';
+
+const sampleCtas: ServiceCta[] = [
+  { label: 'Book Now', href: '/book', variant: 'primary' },
+  { label: 'Call Now – 0435 900 709', href: 'tel:0435900709', variant: 'secondary' },
+  { label: 'View Bundles', href: '/bundles', variant: 'tertiary' }
+];
+
+describe('ServiceCtas', () => {
+  it('renders all CTA links with expected destinations', () => {
+    render(
+      <MemoryRouter>
+        <ServiceCtas ctas={sampleCtas} />
+      </MemoryRouter>
+    );
+
+    const bookLink = screen.getByRole('link', { name: 'Book Now' });
+    const callLink = screen.getByRole('link', { name: 'Call Now – 0435 900 709' });
+    const bundlesLink = screen.getByRole('link', { name: 'View Bundles' });
+
+    expect(bookLink.getAttribute('href')).toBe('/book');
+    expect(callLink.getAttribute('href')).toBe('tel:0435900709');
+    expect(bundlesLink.getAttribute('href')).toBe('/bundles');
+  });
+});

--- a/src/components/services/__tests__/service-page-layout.test.tsx
+++ b/src/components/services/__tests__/service-page-layout.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ServicePageLayout } from '@/components/services/service-page-layout';
+import type { ServiceCta } from '@/components/services/service-ctas';
+
+vi.mock('@/components/SEOHead', () => ({
+  SEOHead: ({ title }: { title: string }) => <div data-testid="seo-head">{title}</div>
+}));
+
+vi.mock('@/components/StructuredData', () => ({
+  StructuredData: () => null
+}));
+
+const ctas: ServiceCta[] = [
+  { label: 'Book', href: '/book', variant: 'primary' },
+  { label: 'Call', href: 'tel:0435900709', variant: 'secondary' }
+];
+
+describe('ServicePageLayout', () => {
+  it('renders hero, content, related links, and trust signals', () => {
+    render(
+      <MemoryRouter>
+        <ServicePageLayout
+          seo={{ title: 'Example Service', description: 'Example description' }}
+          hero={{ title: 'Hero Title', subtitle: 'Hero Subtitle' }}
+          ctas={ctas}
+          trustSignals={['Licensed & insured']}
+          relatedLinks={[{ label: 'More Info', href: '/more' }]}
+          structuredData={{
+            serviceName: 'Example',
+            serviceDescription: 'Details',
+            pageUrl: 'https://example.com'
+          }}
+        >
+          <section>
+            <h2>Content Section</h2>
+            <p>Body copy</p>
+          </section>
+        </ServicePageLayout>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Hero Title')).toBeTruthy();
+    expect(screen.getByText('Hero Subtitle')).toBeTruthy();
+    expect(screen.getByText('Content Section')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'More Info' }).getAttribute('href')).toBe('/more');
+    expect(screen.getByText('Licensed & insured')).toBeTruthy();
+  });
+});

--- a/src/components/services/service-ctas.tsx
+++ b/src/components/services/service-ctas.tsx
@@ -1,0 +1,79 @@
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Link } from 'react-router-dom';
+
+export type ServiceCtaVariant = 'primary' | 'secondary' | 'tertiary';
+
+export interface ServiceCta {
+  label: string;
+  href: string;
+  variant: ServiceCtaVariant;
+}
+
+interface ServiceCtasProps {
+  ctas: ServiceCta[];
+  align?: 'left' | 'center' | 'stretch';
+  className?: string;
+}
+
+const mapVariantToButton = (variant: ServiceCtaVariant): {
+  variant: ButtonProps['variant'];
+  className?: string;
+} => {
+  switch (variant) {
+    case 'primary':
+      return { variant: 'default' };
+    case 'secondary':
+      return { variant: 'outline', className: 'border-primary/40 text-primary hover:text-primary' };
+    case 'tertiary':
+      return { variant: 'link', className: 'text-primary font-semibold' };
+    default:
+      return { variant: 'default' };
+  }
+};
+
+const ServiceCtas = ({ ctas, align = 'left', className }: ServiceCtasProps) => {
+  const isCenter = align === 'center';
+  const isStretch = align === 'stretch';
+  const containerClasses = cn(
+    'flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center',
+    isCenter && 'sm:justify-center',
+    !isCenter && !isStretch && 'sm:justify-start',
+    isStretch && 'sm:justify-start sm:[&>*]:flex-1',
+    className
+  );
+
+  return (
+    <div className={containerClasses}>
+      {ctas.map((cta) => {
+        const { variant, className: variantClassName } = mapVariantToButton(cta.variant);
+        const isTel = cta.href.startsWith('tel:');
+        const buttonClassName = cn(variantClassName, 'min-w-[200px] text-center');
+
+        if (isTel) {
+          return (
+            <Button key={cta.label} variant={variant} size="lg" asChild className={buttonClassName}>
+              <a href={cta.href}>{cta.label}</a>
+            </Button>
+          );
+        }
+
+        if (cta.href.startsWith('http')) {
+          return (
+            <Button key={cta.label} variant={variant} size="lg" asChild className={buttonClassName}>
+              <a href={cta.href}>{cta.label}</a>
+            </Button>
+          );
+        }
+
+        return (
+          <Button key={cta.label} variant={variant} size="lg" asChild className={buttonClassName}>
+            <Link to={cta.href}>{cta.label}</Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+};
+
+export { ServiceCtas };

--- a/src/components/services/service-page-layout.tsx
+++ b/src/components/services/service-page-layout.tsx
@@ -1,0 +1,106 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { SEOHead } from '@/components/SEOHead';
+import { StructuredData } from '@/components/StructuredData';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { cn } from '@/lib/utils';
+
+interface ServicePageLayoutProps {
+  seo: {
+    title: string;
+    description: string;
+  };
+  hero: {
+    title: string;
+    subtitle: string;
+  };
+  intro?: ReactNode;
+  ctas: ServiceCta[];
+  trustSignals: string[];
+  children: ReactNode;
+  relatedLinks?: {
+    label: string;
+    href: string;
+  }[];
+  structuredData?: {
+    serviceName: string;
+    serviceDescription: string;
+    pageUrl: string;
+  };
+  className?: string;
+}
+
+const ServicePageLayout = ({
+  seo,
+  hero,
+  intro,
+  ctas,
+  trustSignals,
+  children,
+  relatedLinks,
+  structuredData,
+  className
+}: ServicePageLayoutProps) => {
+  return (
+    <div className={cn('min-h-screen bg-gradient-to-b from-background to-muted/10', className)}>
+      <SEOHead title={seo.title} description={seo.description} />
+      {structuredData ? (
+        <StructuredData
+          type="service"
+          serviceName={structuredData.serviceName}
+          serviceDescription={structuredData.serviceDescription}
+          pageUrl={structuredData.pageUrl}
+        />
+      ) : null}
+
+      <section className="bg-gradient-to-br from-primary via-primary/90 to-[#0B3B69] py-20 text-white">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">{hero.title}</h1>
+          <p className="mb-8 mx-auto max-w-3xl text-lg text-white/90 md:text-xl">{hero.subtitle}</p>
+          <ServiceCtas ctas={ctas} align="center" className="justify-center" />
+        </div>
+      </section>
+
+      <main className="container mx-auto px-4 py-16">
+        {intro ? (
+          <div className="mx-auto mb-12 max-w-3xl text-center text-lg text-muted-foreground">{intro}</div>
+        ) : null}
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-16 text-left">
+          {children}
+          {relatedLinks ? (
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold tracking-tight">Related Links</h2>
+              <ul className="space-y-3 text-primary">
+                {relatedLinks.map((link) => (
+                  <li key={link.href}>
+                    {link.href.startsWith('http') ? (
+                      <a href={link.href} className="font-semibold hover:underline">
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link to={link.href} className="font-semibold hover:underline">
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          <section>
+            <h2 className="mb-4 text-2xl font-semibold tracking-tight">Trust</h2>
+            <div className="flex flex-wrap gap-3 text-sm font-semibold text-primary">
+              {trustSignals.map((signal) => (
+                <span key={signal} className="rounded-full bg-primary/10 px-4 py-2 text-primary">
+                  {signal}
+                </span>
+              ))}
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export { ServicePageLayout };

--- a/src/constants/company.ts
+++ b/src/constants/company.ts
@@ -1,0 +1,5 @@
+export const COMPANY_NAME = 'Call Kaids Roofing';
+export const COMPANY_PHONE = '0435900709';
+export const COMPANY_PHONE_DISPLAY = '0435 900 709';
+export const COMPANY_PHONE_TEL = `tel:${COMPANY_PHONE}`;
+export const SERVICE_AREAS_SUMMARY = 'Clyde North & Southeast Melbourne';

--- a/src/pages/Bundles.tsx
+++ b/src/pages/Bundles.tsx
@@ -1,0 +1,104 @@
+import { CheckCircle2, Layers3 } from 'lucide-react';
+import { ServicePageLayout } from '@/components/services/service-page-layout';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
+
+const ctas: ServiceCta[] = [
+  { label: 'View Bundles', href: '#bundles', variant: 'primary' },
+  { label: 'Book Bundle', href: '/book', variant: 'secondary' },
+  { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'tertiary' }
+];
+
+const whyBundle = [
+  'Lower callout costs',
+  'One coordinated schedule',
+  'Extended roof life for less'
+];
+
+const bundlesOffered = [
+  {
+    name: 'Bundle A',
+    description: 'Ridge Rebedding & Repointing + Pressure Wash'
+  },
+  {
+    name: 'Bundle B',
+    description: 'Gutter Cleaning + Minor Ridge Repointing'
+  },
+  {
+    name: 'Bundle C',
+    description: 'Valley Iron Replacement + Leak Make-Safe'
+  },
+  {
+    name: 'Bundle D',
+    description: 'Health Check + Maintenance Pack (Gutter Clean + Minor Reseals)'
+  }
+];
+
+const relatedLinks = [
+  { label: 'Learn about Featured Services', href: '/services' },
+  { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
+];
+
+const Bundles = () => {
+  return (
+    <ServicePageLayout
+      seo={{
+        title: 'Roof Bundle Deals Clyde North – Save More | Call Kaids Roofing',
+        description:
+          'Save 10–20% by combining services in one visit. Choose from ridge, cleaning, leak, and maintenance bundles. Serving Clyde North & SE Melbourne with transparent fixed pricing and licensed trades.'
+      }}
+      hero={{
+        title: 'Bundle Deals',
+        subtitle: 'Save money and time by combining essential services in one booking.'
+      }}
+      ctas={ctas}
+      trustSignals={['Fully licensed & insured', 'Transparent fixed pricing']}
+      relatedLinks={relatedLinks}
+      structuredData={{
+        serviceName: 'Roof Bundle Deals',
+        serviceDescription:
+          'Bundled roofing services including ridge repointing, cleaning, leak repairs, and maintenance packs with 10–20% savings for Clyde North and Southeast Melbourne homeowners.',
+        pageUrl: 'https://callkaidsroofing.com.au/bundles'
+      }}
+    >
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Why Bundle?</h2>
+        <ul className="space-y-3 text-muted-foreground">
+          {whyBundle.map((reason) => (
+            <li key={reason} className="flex items-start gap-3">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <span>{reason}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section id="bundles">
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Bundles Offered</h2>
+        <div className="space-y-4">
+          {bundlesOffered.map((bundle) => (
+            <div key={bundle.name} className="rounded-2xl border border-primary/10 bg-background p-6 shadow-sm">
+              <div className="flex items-start gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Layers3 className="h-6 w-6" aria-hidden />
+                </div>
+                <div>
+                  <h3 className="text-xl font-semibold text-foreground">{bundle.name}</h3>
+                  <p className="text-muted-foreground">{bundle.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-6 text-sm text-muted-foreground">Each bundle saves 10–20% versus standalone services.</p>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">CTAs</h2>
+        <ServiceCtas ctas={ctas} />
+      </section>
+    </ServicePageLayout>
+  );
+};
+
+export default Bundles;

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,230 +1,243 @@
 import { Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Shield, Award, Star, Phone, ArrowRight } from 'lucide-react';
+import { CheckCircle2, ArrowRight } from 'lucide-react';
 import { SEOHead } from '@/components/SEOHead';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
 
-export default function Services() {
-  const services = [
-    {
-      title: 'Roof Restoration',
-      summary: 'Stop leaks and renew your roof for 60-70% less than replacement.',
-      description: 'Complete restoration including cleaning, repairs, rebedding and repointing with premium materials.',
-      href: '/services/roof-restoration',
-      badge: 'Most Popular'
-    },
-    {
-      title: 'Roof Painting',
-      summary: 'Refresh your roof colour in 2-3 days using premium paints designed for Melbourne weather.',
-      description: 'Professional roof painting with high-quality paints and 10-year warranty.',
-      href: '/services/roof-painting',
-      badge: 'Quick Turnaround'
-    },
-    {
-      title: 'Roof Repairs',
-      summary: 'Fix leaks, replace broken tiles and restore your roof integrity.',
-      description: 'Expert repairs using quality materials with same-day emergency service available.',
-      href: '/services/roof-repairs',
-      badge: 'Emergency Available'
-    },
-    {
-      title: 'Gutter Cleaning',
-      summary: 'Professional gutter cleaning and maintenance to protect your property.',
-      description: 'Thorough cleaning and inspection with photo evidence of work completed.',
-      href: '/services/gutter-cleaning'
-    },
-    {
-      title: 'Roof Repointing',
-      summary: 'Secure ridge caps and seal your roof against Melbourne weather.',
-      description: 'Professional rebedding and repointing using premium SupaPoint mortar.',
-      href: '/services/roof-repointing'
-    },
-    {
-      title: 'Tile Replacement',
-      summary: 'Replace broken or damaged tiles with exact matches.',
-      description: 'Professional tile replacement with matching colours and quality materials.',
-      href: '/services/tile-replacement'
-    },
-    {
-      title: 'Valley Iron Replacement',
-      summary: 'Replace rusted valley irons to prevent leaks and water damage.',
-      description: 'Complete valley iron replacement with proper sealing and weatherproofing.',
-      href: '/services/valley-iron-replacement'
-    },
-    {
-      title: 'Leak Detection',
-      summary: 'Expert leak detection and repair to protect your home.',
-      description: 'Professional assessment and repair of roof leaks with guaranteed results.',
-      href: '/services/leak-detection'
-    }
-  ];
+const pageCtas: ServiceCta[] = [
+  { label: 'Book Your Free Roof Health Check', href: '/book', variant: 'primary' },
+  { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
+];
 
+const featuredServices = [
+  {
+    title: 'Roof Restoration',
+    value: 'Clean, repair, and protect your roof with a full restoration using Dulux membranes and a 10-year warranty.',
+    benefits: [
+      'Stops leaks and prevents water damage',
+      'Adds years to your roof with premium Dulux membranes',
+      'Includes ridge rebedding, repointing, and photo proof'
+    ],
+    slug: '/roof-restoration'
+  },
+  {
+    title: 'Ridge Rebedding & Repointing',
+    value: 'Secure ridges and restore stability to your roof with expert rebedding and repointing, backed by our 10-year warranty.',
+    benefits: [
+      'Reseals and stabilises ridge caps for leak-free performance',
+      'Extends roof life with durable compounds designed for Melbourne weather',
+      'Photo proof and clean-up included'
+    ],
+    slug: '/ridge-repointing'
+  },
+  {
+    title: 'Leak Repairs',
+    value: 'Fix leaks fast with professional repairs and make-safe solutions, preventing costly damage to your home.',
+    benefits: [
+      'Stops active leaks and prevents new ones',
+      'Includes tile replacement, valley repair, and minor resealing',
+      'Fast response with photo-backed proof on completion'
+    ],
+    slug: '/leak-repairs'
+  }
+];
+
+const additionalServices = [
+  {
+    name: 'Roof Pressure Cleaning',
+    description: 'Thoroughly cleans tiles and valleys to remove dirt, moss, and lichen.',
+    href: '/services/roof-pressure-cleaning'
+  },
+  {
+    name: 'Valley Iron Replacement',
+    description: 'Replaces rusted or damaged valley irons to ensure proper water runoff.',
+    href: '/services/valley-iron-replacement'
+  },
+  {
+    name: 'Gutter Cleaning',
+    description: 'Clears gutters and downpipes to prevent blockages and protect fascia and foundations.',
+    href: '/services/gutter-cleaning'
+  },
+  {
+    name: 'Resarking & Battening',
+    description: 'Replaces sarking and battens for improved waterproofing and insulation.',
+    href: '/services/resarking-battening'
+  },
+  {
+    name: 'Re-roof & Extensions',
+    description: 'Provides seamless re-roofing and tie-ins for extensions with matched materials and flashings.',
+    href: '/services/re-roof-extensions'
+  },
+  {
+    name: 'Free Roof Health Check',
+    description: 'Offers a no-obligation inspection and report so you know the condition of your roof.',
+    href: '/services/health-check'
+  }
+];
+
+const bundles = [
+  'Bundle A: Ridge Rebedding & Repointing + Pressure Wash',
+  'Bundle B: Gutter Cleaning + Minor Ridge Repointing',
+  'Bundle C: Valley Iron Replacement + Leak Make-Safe',
+  'Bundle D: Health Check + Maintenance Pack'
+];
+
+const trustSignals = [
+  '500+ happy customers',
+  '4.9/5 stars',
+  'Fully licensed & insured',
+  'Dulux membranes',
+  '10-year workmanship warranty'
+];
+
+const serviceAreas = [
+  'Clyde North',
+  'Pakenham',
+  'Narre Warren',
+  'Cranbourne',
+  'Berwick',
+  'Frankston',
+  'Dandenong',
+  'Brighton',
+  'Suburbs within 50 km of Clyde North'
+];
+
+const Services = () => {
   return (
-    <>
-      <SEOHead 
-        title="Roofing Services Melbourne | Call Kaids Roofing"
-        description="Professional roofing services in Melbourne. Roof restoration, painting, repairs & more. 10-year warranty. Owner-operated business serving SE Melbourne."
-        keywords="roofing services Melbourne, roof restoration, roof painting, roof repairs, gutter cleaning, Melbourne roofer"
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/10">
+      <SEOHead
+        title="Roofing Services Clyde North & SE Melbourne – 10-Year Warranty | Call Kaids Roofing"
+        description="Explore our range of featured and additional roofing services in Clyde North and SE Melbourne. Benefit from Dulux products, a 10-year workmanship warranty, and a free roof health check."
       />
-      
-      <div className="min-h-screen bg-gradient-to-br from-background to-muted/20">
-        {/* Hero Section */}
-        <div className="bg-gradient-to-r from-primary to-primary/80 text-white py-20">
-          <div className="container mx-auto px-4 text-center">
-            <h1 className="text-4xl md:text-5xl font-bold mb-6">
-              Our Roofing Services
-            </h1>
-            <p className="text-xl mb-8 max-w-3xl mx-auto text-white/90">
-              Professional roofing solutions for Southeast Melbourne. Quality workmanship, premium materials, and 10-year warranties on all major work.
-            </p>
-            
-            {/* Trust indicators */}
-            <div className="flex flex-wrap justify-center gap-4 mb-8">
-              <div className="flex items-center gap-2 bg-white/20 backdrop-blur-sm px-4 py-2 rounded-full">
-                <Shield className="h-5 w-5" />
-                <span>Fully Insured</span>
-              </div>
-              <div className="flex items-center gap-2 bg-white/20 backdrop-blur-sm px-4 py-2 rounded-full">
-                <Award className="h-5 w-5" />
-                <span>10 Year Warranty</span>
-              </div>
-              <div className="flex items-center gap-2 bg-white/20 backdrop-blur-sm px-4 py-2 rounded-full">
-                <Star className="h-5 w-5" />
-                <span>200+ Happy Customers</span>
-              </div>
-            </div>
 
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a 
-                href="tel:0435900709"
-                className="flex items-center gap-3 bg-white text-primary px-8 py-4 rounded-lg font-bold text-lg hover:bg-white/90 transition-colors shadow-lg"
-              >
-                <Phone className="h-5 w-5" />
-                Call 0435 900 709
-              </a>
-              <Button asChild variant="outline" size="lg" className="bg-white/20 border-white text-white hover:bg-white hover:text-primary">
-                <Link to="/book">Get Free Quote</Link>
-              </Button>
-            </div>
+      <section className="bg-gradient-to-br from-primary via-primary/90 to-[#0B3B69] py-20 text-white">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">Roofing Services in Clyde North & SE Melbourne</h1>
+          <p className="mx-auto max-w-3xl text-lg text-white/90 md:text-xl">
+            Discover all our roofing services from restoration and repairs to inspections and bundles. Our top services are featured first, making it easy to find exactly what your roof needs.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <ServiceCtas ctas={pageCtas} align="center" />
           </div>
         </div>
+      </section>
 
-        {/* Services Grid */}
-        <div className="container mx-auto px-4 py-16">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {services.map((service) => (
-              <Card key={service.title} className="h-full hover:shadow-lg transition-shadow">
-                <CardHeader>
-                  <div className="flex justify-between items-start">
-                    <CardTitle className="text-xl font-bold">{service.title}</CardTitle>
-                    {service.badge && (
-                      <Badge variant="secondary" className="text-xs">
-                        {service.badge}
-                      </Badge>
-                    )}
-                  </div>
-                  <CardDescription className="text-base font-medium text-primary">
-                    {service.summary}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="flex-1 flex flex-col">
-                  <p className="text-muted-foreground mb-6 flex-1">
-                    {service.description}
-                  </p>
-                  <Link to={service.href}>
-                    <Button className="w-full group">
-                      Learn More 
-                      <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
-                    </Button>
+      <main className="container mx-auto px-4 py-16">
+        <section className="mb-16">
+          <h2 className="text-3xl font-semibold tracking-tight">Featured Services</h2>
+          <p className="mt-2 max-w-3xl text-muted-foreground">
+            These are the services homeowners book most often for long-lasting, compliant results backed by our 10-year workmanship warranty.
+          </p>
+          <div className="mt-10 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+            {featuredServices.map((service) => (
+              <div key={service.title} className="flex h-full flex-col rounded-2xl border border-primary/10 bg-background p-6 shadow-sm">
+                <div className="flex-1">
+                  <h3 className="text-xl font-semibold text-foreground">{service.title}</h3>
+                  <p className="mt-3 text-muted-foreground">{service.value}</p>
+                  <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                    {service.benefits.map((benefit) => (
+                      <li key={benefit} className="flex items-start gap-2">
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" aria-hidden />
+                        <span>{benefit}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="mt-6 flex flex-col gap-3">
+                  <ServiceCtas ctas={pageCtas} align="stretch" />
+                  <Link to={service.slug} className="flex items-center justify-center gap-2 text-sm font-semibold text-primary hover:underline">
+                    Learn more
+                    <ArrowRight className="h-4 w-4" aria-hidden />
                   </Link>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             ))}
           </div>
-        </div>
+        </section>
 
-        {/* Suburb-Specific Services Section */}
-        <div className="bg-gradient-to-r from-primary/5 to-secondary/5 py-16">
-          <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-bold mb-4 text-center">Local Roofing Experts Across Southeast Melbourne</h2>
-            <p className="text-lg text-muted-foreground mb-8 text-center max-w-3xl mx-auto">
-              Kaidyn knows every suburb personally. Get specialised service tailored to your area's specific roofing needs and regulations.
-            </p>
-            
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-              <Card className="hover:shadow-lg transition-shadow">
-                <CardHeader>
-                  <CardTitle className="text-xl">Clyde North & Officer</CardTitle>
-                  <CardDescription>Home base - know every street and building style</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    <Link to="/services/roof-restoration-clyde-north" className="block text-primary hover:underline">• Roof Restoration Clyde North</Link>
-                    <Link to="/services/roof-painting-clyde-north" className="block text-primary hover:underline">• Roof Painting Clyde North</Link>
-                    <p className="text-sm text-muted-foreground mt-2">New estates, modern materials, quality finishes</p>
-                  </div>
-                </CardContent>
-              </Card>
-              
-              <Card className="hover:shadow-lg transition-shadow">
-                <CardHeader>
-                  <CardTitle className="text-xl">Berwick & Pakenham</CardTitle>
-                  <CardDescription>Major service areas - family-focused communities</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    <Link to="/services/roof-restoration-berwick" className="block text-primary hover:underline">• Berwick Roof Specialist</Link>
-                    <Link to="/services/roof-restoration-pakenham" className="block text-primary hover:underline">• Pakenham Roof Restoration</Link>
-                    <Link to="/services/roof-painting-pakenham" className="block text-primary hover:underline">• Pakenham Roof Painting</Link>
-                    <p className="text-sm text-muted-foreground mt-2">Established homes, renovation projects, quality upgrades</p>
-                  </div>
-                </CardContent>
-              </Card>
-              
-              <Card className="hover:shadow-lg transition-shadow">
-                <CardHeader>
-                  <CardTitle className="text-xl">Cranbourne & Beyond</CardTitle>
-                  <CardDescription>High-volume service area - growing rapidly</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    <Link to="/services/roof-restoration-cranbourne" className="block text-primary hover:underline">• Cranbourne Roof Restoration</Link>
-                    <Link to="/services/roof-painting-cranbourne" className="block text-primary hover:underline">• Cranbourne Roof Painting</Link>
-                    <Link to="/services/roof-restoration-mount-eliza" className="block text-primary hover:underline">• Mount Eliza Premium Service</Link>
-                    <p className="text-sm text-muted-foreground mt-2">Mix of new and established, diverse roof types</p>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </div>
-
-        {/* Call to Action Section */}
-        <div className="bg-primary/5 py-16">
-          <div className="container mx-auto px-4 text-center">
-            <h2 className="text-3xl font-bold mb-4">Ready to Get Started?</h2>
-            <p className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto">
-              Get your free roof health check from Kaidyn. No pressure, just honest advice about your roof's condition and what it needs.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a 
-                href="tel:0435900709"
-                className="flex items-center gap-3 bg-primary text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-primary/90 transition-colors shadow-lg"
+        <section className="mb-16">
+          <h2 className="text-3xl font-semibold tracking-tight">Additional Services</h2>
+          <p className="mt-2 max-w-3xl text-muted-foreground">
+            Our additional services complement the featured work and can be booked separately or as part of a bundle.
+          </p>
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {additionalServices.map((service) => (
+              <Link
+                key={service.name}
+                to={service.href}
+                className="group flex flex-col justify-between rounded-2xl border border-primary/10 bg-background p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
               >
-                <Phone className="h-5 w-5" />
-                Call Now: 0435 900 709
-              </a>
-              <Button asChild variant="outline" size="lg">
-                <Link to="/book">Book Free Assessment</Link>
-              </Button>
-            </div>
-            <p className="text-sm text-muted-foreground mt-4">
-              Usually 2-3 weeks out • Emergency repairs: Same day
-            </p>
+                <div>
+                  <h3 className="text-lg font-semibold text-foreground group-hover:text-primary">{service.name}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{service.description}</p>
+                </div>
+                <span className="mt-4 inline-flex items-center text-sm font-semibold text-primary">
+                  Explore service
+                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
+                </span>
+              </Link>
+            ))}
           </div>
-        </div>
-      </div>
-    </>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="text-3xl font-semibold tracking-tight">Bundles</h2>
+          <p className="mt-2 max-w-3xl text-muted-foreground">
+            Save 10–20% by combining services in one visit with our bundle deals. Choose from four options designed to extend your roof’s life for less.
+          </p>
+          <ul className="mt-6 space-y-3 text-muted-foreground">
+            {bundles.map((bundle) => (
+              <li key={bundle} className="flex items-start gap-3">
+                <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+                <span>{bundle}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6">
+            <Link to="/bundles" className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline">
+              View bundle deals
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="text-3xl font-semibold tracking-tight">Trust Block</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            {trustSignals.map((signal) => (
+              <span key={signal} className="rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
+                {signal}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="text-3xl font-semibold tracking-tight">Service Areas</h2>
+          <p className="mt-2 max-w-3xl text-muted-foreground">
+            We serve Clyde North, Pakenham, Narre Warren, Cranbourne, Berwick, Frankston, Dandenong, Brighton, and suburbs within 50 km of Clyde North.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {serviceAreas.map((area) => (
+              <div key={area} className="rounded-2xl border border-primary/10 bg-background p-4 text-sm font-medium text-foreground shadow-sm">
+                {area}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-primary/10 bg-primary/5 p-10 text-center shadow-sm">
+          <h2 className="text-3xl font-semibold tracking-tight">Ready to book Kaidyn?</h2>
+          <p className="mt-2 text-lg text-muted-foreground">
+            Secure your spot for a free roof health check or call for fast advice. We keep scheduling simple and transparent.
+          </p>
+          <div className="mt-6 flex justify-center">
+            <ServiceCtas ctas={pageCtas} align="center" />
+          </div>
+        </section>
+      </main>
+    </div>
   );
-}
+};
+
+export default Services;

--- a/src/pages/services/HealthCheck.tsx
+++ b/src/pages/services/HealthCheck.tsx
@@ -4,23 +4,20 @@ import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas
 import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
 
 const ctas: ServiceCta[] = [
-  { label: 'Book Now', href: '/book', variant: 'primary' },
+  { label: 'Book Free Check', href: '/book', variant: 'primary' },
   { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
 ];
 
-const whatsIncluded = [
-  'Full debris removal from gutters and valleys',
-  'Downpipe flush where accessible',
-  'Minor seal checks and repairs',
-  'Before/after photo proof',
-  'Debris disposal off-site'
+const whatYouGet = [
+  'Visual inspection of roof, ridges, valleys, flashings, and gutters',
+  'Photos and written condition report',
+  'Priority scheduling if repairs are needed'
 ];
 
 const benefits = [
-  'Prevents leaks, staining, and rot',
-  'Protects fascia and foundations',
-  'Improves roof lifespan',
-  'Eliminates pest and mosquito breeding grounds'
+  'Catch issues early and avoid emergencies',
+  'No-obligation check, completely free',
+  'Trusted by 500+ homeowners in Clyde North & SE Melbourne'
 ];
 
 const serviceAreas = [
@@ -36,37 +33,37 @@ const serviceAreas = [
 ];
 
 const relatedLinks = [
-  { label: 'Learn about Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
-  { label: 'View Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
-  { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
+  { label: 'Learn about Roof Restoration', href: '/services/roof-restoration' },
+  { label: 'View Leak Repairs', href: '/services/leak-repairs' },
+  { label: 'View Bundle Deals', href: '/bundles' }
 ];
 
-const GutterCleaning = () => {
+const HealthCheck = () => {
   return (
     <ServicePageLayout
       seo={{
-        title: 'Gutter Cleaning Clyde North – Prevent Overflows | Call Kaids Roofing',
+        title: 'Free Roof Health Check Clyde North | Call Kaids Roofing',
         description:
-          'Keep gutters and downpipes clear with professional cleaning and photo proof. Prevent water damage and foundation issues. Serving Clyde North & SE Melbourne.'
+          'Catch problems before they leak. Get a free photo-based roof health check with a written report and fixed-price quote if issues are found. Trusted by 500+ homeowners in Clyde North & SE Melbourne.'
       }}
       hero={{
-        title: 'Gutter Cleaning',
-        subtitle: 'Stay off the ladder — we keep your gutters clear, safe, and flowing.'
+        title: 'Free Roof Health Check',
+        subtitle: 'Know your roof’s condition before it costs you thousands.'
       }}
       ctas={ctas}
-      trustSignals={['Licensed & insured', 'Safety harnesses always used']}
+      trustSignals={['4.9/5 star rating', 'No hidden extras']}
       relatedLinks={relatedLinks}
       structuredData={{
-        serviceName: 'Gutter Cleaning',
+        serviceName: 'Free Roof Health Check',
         serviceDescription:
-          'Professional gutter and downpipe cleaning with debris removal, minor repairs, and photo proof across Clyde North and Southeast Melbourne.',
-        pageUrl: 'https://callkaidsroofing.com.au/services/gutter-cleaning'
+          'Complimentary roof inspection with photos, written report, and fixed-price quotes for homes across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/health-check'
       }}
     >
       <section>
-        <h2 className="mb-4 text-2xl font-semibold tracking-tight">What’s Included</h2>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">What You Get</h2>
         <ul className="space-y-3 text-muted-foreground">
-          {whatsIncluded.map((item) => (
+          {whatYouGet.map((item) => (
             <li key={item} className="flex items-start gap-3">
               <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
               <span>{item}</span>
@@ -109,4 +106,4 @@ const GutterCleaning = () => {
   );
 };
 
-export default GutterCleaning;
+export default HealthCheck;

--- a/src/pages/services/ReroofAndExtensions.tsx
+++ b/src/pages/services/ReroofAndExtensions.tsx
@@ -8,19 +8,26 @@ const ctas: ServiceCta[] = [
   { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
 ];
 
-const whatsIncluded = [
-  'Full debris removal from gutters and valleys',
-  'Downpipe flush where accessible',
-  'Minor seal checks and repairs',
-  'Before/after photo proof',
-  'Debris disposal off-site'
+const scopes = [
+  'Full re-roof (tile or metal)',
+  'Extension tie-ins with saddles and aprons',
+  'New valleys, ridges, and flashings',
+  'Compliance certification provided'
 ];
 
 const benefits = [
-  'Prevents leaks, staining, and rot',
-  'Protects fascia and foundations',
-  'Improves roof lifespan',
-  'Eliminates pest and mosquito breeding grounds'
+  'Profile and colour matched to existing roof',
+  'Leak-free finishes with correct flashings',
+  'Full compliance with building codes',
+  'Boosts home value and longevity'
+];
+
+const process = [
+  'Strip and inspect existing structure',
+  'Install sarking and battens',
+  'Fit new roof materials with valleys and flashings',
+  'Quality assurance and hose-test',
+  'Provide compliance certification'
 ];
 
 const serviceAreas = [
@@ -36,37 +43,37 @@ const serviceAreas = [
 ];
 
 const relatedLinks = [
-  { label: 'Learn about Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
-  { label: 'View Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
+  { label: 'Learn about Resarking & Battening', href: '/services/resarking-battening' },
+  { label: 'View Roof Restoration', href: '/services/roof-restoration' },
   { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
 ];
 
-const GutterCleaning = () => {
+const ReroofAndExtensions = () => {
   return (
     <ServicePageLayout
       seo={{
-        title: 'Gutter Cleaning Clyde North – Prevent Overflows | Call Kaids Roofing',
+        title: 'Re-roof & Extensions Clyde North – Tie-in Specialists | Call Kaids Roofing',
         description:
-          'Keep gutters and downpipes clear with professional cleaning and photo proof. Prevent water damage and foundation issues. Serving Clyde North & SE Melbourne.'
+          'Full or partial re-roofs and seamless tie-ins for extensions with matched profiles and flashings. Serving Clyde North & SE Melbourne with compliance certification and a 10-year workmanship warranty.'
       }}
       hero={{
-        title: 'Gutter Cleaning',
-        subtitle: 'Stay off the ladder — we keep your gutters clear, safe, and flowing.'
+        title: 'Re-roof & Extensions',
+        subtitle: 'Seamless tie-ins and compliant re-roofs that match your home perfectly.'
       }}
       ctas={ctas}
-      trustSignals={['Licensed & insured', 'Safety harnesses always used']}
+      trustSignals={['Compliance certificates included', 'Fully licensed & insured']}
       relatedLinks={relatedLinks}
       structuredData={{
-        serviceName: 'Gutter Cleaning',
+        serviceName: 'Re-roof & Extensions',
         serviceDescription:
-          'Professional gutter and downpipe cleaning with debris removal, minor repairs, and photo proof across Clyde North and Southeast Melbourne.',
-        pageUrl: 'https://callkaidsroofing.com.au/services/gutter-cleaning'
+          'Full and partial re-roofing, extension tie-ins, and compliance-certified finishing across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/re-roof-extensions'
       }}
     >
       <section>
-        <h2 className="mb-4 text-2xl font-semibold tracking-tight">What’s Included</h2>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Scopes</h2>
         <ul className="space-y-3 text-muted-foreground">
-          {whatsIncluded.map((item) => (
+          {scopes.map((item) => (
             <li key={item} className="flex items-start gap-3">
               <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
               <span>{item}</span>
@@ -85,6 +92,20 @@ const GutterCleaning = () => {
             </li>
           ))}
         </ul>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Process</h2>
+        <ol className="space-y-4 text-muted-foreground">
+          {process.map((step, index) => (
+            <li key={step} className="flex gap-4">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="pt-2 text-base">{step}</span>
+            </li>
+          ))}
+        </ol>
       </section>
 
       <section>
@@ -109,4 +130,4 @@ const GutterCleaning = () => {
   );
 };
 
-export default GutterCleaning;
+export default ReroofAndExtensions;

--- a/src/pages/services/ResarkingAndBattening.tsx
+++ b/src/pages/services/ResarkingAndBattening.tsx
@@ -8,27 +8,20 @@ const ctas: ServiceCta[] = [
   { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
 ];
 
-const whatsIncluded = [
-  'Replacement of cracked or broken tiles',
-  'Valley iron repair or replacement',
-  'Minor reseals and flashing adjustments',
-  'Leak make-safe and emergency patches',
-  'Photo evidence on completion'
-];
-
 const benefits = [
-  'Stops active leaks and prevents water damage',
-  'Protects interiors and prevents mould growth',
-  'Extends the life of your roof',
-  'Free roof health check and fixed-price quote'
+  'Stops wind-driven rain and leaks',
+  'Improves insulation performance',
+  'Restores roof structure and alignment',
+  'Prepares roof for restoration or coating',
+  'Compliant with Australian Standards'
 ];
 
 const process = [
-  'Free roof health check and leak assessment',
-  'Identify sources of leaks and weak points',
-  'Replace broken tiles and repair valley irons',
-  'Apply minor reseals and adjust flashings',
-  'Quality assurance and photo proof provided'
+  'Lift and store tiles in work area',
+  'Replace sarking with breathable membrane',
+  'Renew and level battens',
+  'Relay tiles and seal penetrations',
+  'Quality assurance and photos delivered'
 ];
 
 const serviceAreas = [
@@ -44,46 +37,34 @@ const serviceAreas = [
 ];
 
 const relatedLinks = [
-  { label: 'Learn about Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
-  { label: 'View Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
+  { label: 'Learn about Roof Restoration', href: '/services/roof-restoration' },
+  { label: 'View Re-roof & Extensions', href: '/services/re-roof-extensions' },
   { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
 ];
 
-const RoofRepairs = () => {
+const ResarkingAndBattening = () => {
   return (
     <ServicePageLayout
       seo={{
-        title: 'Leak Repairs Clyde North – Fast & Reliable | Call Kaids Roofing',
+        title: 'Resarking & Battening Clyde North – Improve Waterproofing | Call Kaids Roofing',
         description:
-          'Stop roof leaks fast with professional repairs in Clyde North & SE Melbourne. Tile replacement, valley repair, and minor resealing with photo proof. Free roof health check included.'
+          'Renew sarking and battens for better waterproofing, insulation, and roof support. Serving Clyde North & SE Melbourne with a 10-year workmanship warranty and licensed trades.'
       }}
       hero={{
-        title: 'Leak Repairs',
+        title: 'Resarking & Battening',
         subtitle:
-          'Fix leaks quickly before they cause major damage. Our licensed team repairs leaks in Clyde North & SE Melbourne with photo proof and a fixed quote.'
+          'Keep your home dry, cooler in summer, and warmer in winter with new sarking and battens.'
       }}
       ctas={ctas}
-      trustSignals={['500+ happy customers', '4.9/5 stars on local reviews', 'Fully licensed & insured']}
+      trustSignals={['10-year workmanship warranty', 'Fully licensed & insured']}
       relatedLinks={relatedLinks}
       structuredData={{
-        serviceName: 'Leak Repairs',
+        serviceName: 'Resarking & Battening',
         serviceDescription:
-          'Tile replacement, valley iron repairs, and emergency leak make-safe services with free roof health checks across Clyde North and Southeast Melbourne.',
-        pageUrl: 'https://callkaidsroofing.com.au/services/leak-repairs'
+          'Tile lift, breathable sarking replacement, and batten renewal with compliance to Australian Standards across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/resarking-battening'
       }}
     >
-      <section>
-        <h2 className="mb-4 text-2xl font-semibold tracking-tight">What’s Included</h2>
-        <ul className="space-y-3 text-muted-foreground">
-          {whatsIncluded.map((item) => (
-            <li key={item} className="flex items-start gap-3">
-              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
-              <span>{item}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
       <section>
         <h2 className="mb-4 text-2xl font-semibold tracking-tight">Benefits</h2>
         <ul className="space-y-3 text-muted-foreground">
@@ -132,4 +113,4 @@ const RoofRepairs = () => {
   );
 };
 
-export default RoofRepairs;
+export default ResarkingAndBattening;

--- a/src/pages/services/RoofCleaning.tsx
+++ b/src/pages/services/RoofCleaning.tsx
@@ -9,18 +9,25 @@ const ctas: ServiceCta[] = [
 ];
 
 const whatsIncluded = [
-  'Full debris removal from gutters and valleys',
-  'Downpipe flush where accessible',
-  'Minor seal checks and repairs',
-  'Before/after photo proof',
-  'Debris disposal off-site'
+  'High-pressure wash of tiles, ridges, and valleys',
+  'Removal of moss, lichen, and dirt',
+  'Gutter and downpipe flush where accessible',
+  'Debris disposal off-site',
+  'Photo evidence on completion'
 ];
 
 const benefits = [
-  'Prevents leaks, staining, and rot',
-  'Protects fascia and foundations',
-  'Improves roof lifespan',
-  'Eliminates pest and mosquito breeding grounds'
+  'Removes organic growth and staining',
+  'Improves roof appearance and colour',
+  'Prepares roof for restoration or coating',
+  'Prevents blocked valleys and gutters'
+];
+
+const process = [
+  'Free roof health check and fixed quote',
+  'High-pressure clean of tiles, ridges, valleys, and gutters',
+  'Downpipe flush and debris removal',
+  'Quality assurance and photos delivered'
 ];
 
 const serviceAreas = [
@@ -36,31 +43,32 @@ const serviceAreas = [
 ];
 
 const relatedLinks = [
-  { label: 'Learn about Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
-  { label: 'View Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
+  { label: 'Learn about Roof Restoration', href: '/services/roof-restoration' },
+  { label: 'View Gutter Cleaning', href: '/services/gutter-cleaning' },
   { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
 ];
 
-const GutterCleaning = () => {
+const RoofCleaning = () => {
   return (
     <ServicePageLayout
       seo={{
-        title: 'Gutter Cleaning Clyde North – Prevent Overflows | Call Kaids Roofing',
+        title: 'Roof Pressure Cleaning Clyde North – Remove Moss & Dirt | Call Kaids Roofing',
         description:
-          'Keep gutters and downpipes clear with professional cleaning and photo proof. Prevent water damage and foundation issues. Serving Clyde North & SE Melbourne.'
+          'Power wash your roof tiles to remove moss, lichen, and dirt. Restore colour and prepare for coating. Serving Clyde North & SE Melbourne with photo proof on completion.'
       }}
       hero={{
-        title: 'Gutter Cleaning',
-        subtitle: 'Stay off the ladder — we keep your gutters clear, safe, and flowing.'
+        title: 'Roof Pressure Cleaning',
+        subtitle:
+          'Remove dirt, moss, and lichen with our safe and thorough high-pressure cleaning. Serving Clyde North & SE Melbourne with photo proof and a free roof health check.'
       }}
       ctas={ctas}
-      trustSignals={['Licensed & insured', 'Safety harnesses always used']}
+      trustSignals={['500+ happy customers', '4.9/5 stars on local reviews', 'Fully licensed & insured']}
       relatedLinks={relatedLinks}
       structuredData={{
-        serviceName: 'Gutter Cleaning',
+        serviceName: 'Roof Pressure Cleaning',
         serviceDescription:
-          'Professional gutter and downpipe cleaning with debris removal, minor repairs, and photo proof across Clyde North and Southeast Melbourne.',
-        pageUrl: 'https://callkaidsroofing.com.au/services/gutter-cleaning'
+          'High-pressure roof cleaning for tiles, ridges, and gutters with debris removal and photo documentation across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/roof-pressure-cleaning'
       }}
     >
       <section>
@@ -88,6 +96,20 @@ const GutterCleaning = () => {
       </section>
 
       <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Process</h2>
+        <ol className="space-y-4 text-muted-foreground">
+          {process.map((step, index) => (
+            <li key={step} className="flex gap-4">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="pt-2 text-base">{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section>
         <h2 className="mb-4 text-2xl font-semibold tracking-tight">Service Areas</h2>
         <p className="mb-4 text-muted-foreground">
           Serving Clyde North, Pakenham, Narre Warren, Cranbourne, Berwick, Frankston, Dandenong, Brighton, and suburbs within 50 km.
@@ -109,4 +131,4 @@ const GutterCleaning = () => {
   );
 };
 
-export default GutterCleaning;
+export default RoofCleaning;

--- a/src/pages/services/RoofRepointing.tsx
+++ b/src/pages/services/RoofRepointing.tsx
@@ -1,323 +1,115 @@
-import { SEOHead } from '@/components/SEOHead';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { OptimizedImage } from '@/components/OptimizedImage';
-import { EnhancedContactForm } from '@/components/EnhancedContactForm';
-import { Link } from 'react-router-dom';
-import { Shield, Star, Phone, CheckCircle, AlertTriangle, Clock, Award } from 'lucide-react';
+import { CheckCircle2 } from 'lucide-react';
+import { ServicePageLayout } from '@/components/services/service-page-layout';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
+
+const ctas: ServiceCta[] = [
+  { label: 'Book Your Free Roof Health Check', href: '/book', variant: 'primary' },
+  { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
+];
+
+const benefits = [
+  'Reseals and stabilises ridge caps for leak-free performance',
+  'Flexible pointing compound ensures long-lasting seal',
+  'Improves roof appearance and protects against storms',
+  'Includes pressure cleaning and debris removal',
+  'Backed by our 10-year workmanship warranty'
+];
+
+const process = [
+  'Free roof health check and fixed quote',
+  'Remove old mortar and prepare ridges',
+  'Rebed ridges with new bedding',
+  'Repoint with flexible compound',
+  'Quality assurance and photos delivered'
+];
+
+const serviceAreas = [
+  'Clyde North',
+  'Pakenham',
+  'Narre Warren',
+  'Cranbourne',
+  'Berwick',
+  'Frankston',
+  'Dandenong',
+  'Brighton',
+  'Suburbs within 50 km'
+];
+
+const relatedLinks = [
+  { label: 'View Roof Restoration', href: '/services/roof-restoration' },
+  { label: 'Learn about Leak Repairs', href: '/services/leak-repairs' },
+  { label: 'Read about our 10-Year Warranty', href: '/warranty' }
+];
 
 const RoofRepointing = () => {
-  const structuredData = {
-    "@context": "https://schema.org",
-    "@type": "Service",
-    "name": "Roof Repointing Melbourne",
-    "description": "Professional roof repointing services in Southeast Melbourne. Fix cracked mortar, stop leaks, and extend your roof's life with our 10-year warranty.",
-    "provider": {
-      "@type": "RoofingContractor",
-      "name": "Call Kaids Roofing",
-      "telephone": "+61 435 900 709",
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "Grices Rd",
-        "addressLocality": "Clyde North",
-        "addressRegion": "VIC",
-        "postalCode": "3978",
-        "addressCountry": "AU"
-      }
-    },
-    "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
-    "serviceType": "Roof Repointing",
-    "url": "https://callkaidsroofing.com.au/roof-repointing"
-  };
-
   return (
-    <>
-      <SEOHead
-        title="Roof Repointing Melbourne | Ridge Cap & Mortar Repair | Call Kaids Roofing"
-        description="Professional roof repointing in Southeast Melbourne. Fix cracked mortar, stop leaks, and extend your roof's life. 10-year warranty. Call 0435 900 709."
-        keywords="roof repointing Melbourne, ridge cap repair, mortar repair, roof pointing, Clyde North repointing, Southeast Melbourne roofing"
-        structuredData={structuredData}
-      />
+    <ServicePageLayout
+      seo={{
+        title: 'Ridge Rebedding & Repointing Clyde North – 10-Year Warranty | Call Kaids Roofing',
+        description:
+          'Secure your ridge caps with rebedding and repointing using flexible compounds. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and Dulux products.'
+      }}
+      hero={{
+        title: 'Ridge Rebedding & Repointing',
+        subtitle:
+          'Strengthen and reseal your ridges for a leak-free roof. Professional rebedding and repointing in Clyde North & SE Melbourne with photo proof and a 10-year warranty.'
+      }}
+      ctas={ctas}
+      trustSignals={['500+ happy customers', '4.9/5 stars on local reviews', 'Fully licensed & insured']}
+      relatedLinks={relatedLinks}
+      structuredData={{
+        serviceName: 'Ridge Rebedding & Repointing',
+        serviceDescription:
+          'Ridge cap rebedding, flexible repointing compound, and pressure cleaning with a 10-year workmanship warranty across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/ridge-repointing'
+      }}
+    >
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Benefits</h2>
+        <ul className="space-y-3 text-muted-foreground">
+          {benefits.map((benefit) => (
+            <li key={benefit} className="flex items-start gap-3">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
-      <div className="min-h-screen bg-background">
-        {/* Hero Section */}
-        <section className="relative py-16 bg-gradient-to-br from-primary/10 to-secondary/10">
-          <div className="container mx-auto px-4">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-              <div>
-                <Badge variant="secondary" className="mb-4">
-                  Professional Roof Repointing
-                </Badge>
-                <h1 className="text-4xl md:text-5xl font-bold mb-6">
-                  Roof Repointing in <span className="text-primary">Southeast Melbourne</span>
-                </h1>
-                <p className="text-xl text-muted-foreground mb-8">
-                  Fix cracked mortar, stop leaks, and extend your roof's life with our professional repointing services. 
-                  Using premium SupaPoint materials with 10-year warranty.
-                </p>
-                
-                <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                  <Button asChild size="lg" className="bg-primary hover:bg-primary/90">
-                    <a href="tel:0435900709" className="flex items-center gap-2">
-                      <Phone className="h-5 w-5" />
-                      Call 0435 900 709
-                    </a>
-                  </Button>
-                  <Button asChild variant="outline" size="lg">
-                    <Link to="/book">Get Free Assessment</Link>
-                  </Button>
-                </div>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Process</h2>
+        <ol className="space-y-4 text-muted-foreground">
+          {process.map((step, index) => (
+            <li key={step} className="flex gap-4">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="pt-2 text-base">{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
 
-                <div className="flex flex-wrap gap-4 text-sm">
-                  <div className="flex items-center gap-2">
-                    <Shield className="h-4 w-4 text-primary" />
-                    <span>10-Year Warranty</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Star className="h-4 w-4 text-primary" />
-                    <span>Premium Materials</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Award className="h-4 w-4 text-primary" />
-                    <span>25+ Years Combined Experience</span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="relative">
-                <OptimizedImage
-                  src="/lovable-uploads/99c2917f-b2e3-44ab-ba7d-79754ca91997.png"
-                  alt="Professional roof repointing service in Southeast Melbourne"
-                  className="rounded-lg shadow-2xl"
-                  width={600}
-                  height={400}
-                />
-              </div>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Service Areas</h2>
+        <p className="mb-4 text-muted-foreground">
+          Serving Clyde North, Pakenham, Narre Warren, Cranbourne, Berwick, Frankston, Dandenong, Brighton, and suburbs within 50 km.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {serviceAreas.map((area) => (
+            <div key={area} className="rounded-2xl border border-primary/10 bg-background p-4 text-sm font-medium text-foreground shadow-sm">
+              {area}
             </div>
-          </div>
-        </section>
+          ))}
+        </div>
+      </section>
 
-        {/* What's Included Section */}
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Complete Roof Repointing Service</h2>
-              <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-                Our comprehensive repointing service addresses all mortar issues to prevent leaks and extend your roof's lifespan.
-              </p>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {[
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Ridge Cap Repointing",
-                  description: "Complete ridge cap removal, cleaning, and repointing with premium SupaPoint mortar."
-                },
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Gable End Pointing",
-                  description: "Detailed gable end mortar repair and repointing to prevent water penetration."
-                },
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Tile Bedding Repair",
-                  description: "Replace cracked or missing tile bedding with flexible pointing compound."
-                },
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Leak Detection",
-                  description: "Thorough inspection to identify and fix all mortar-related leak points."
-                },
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Quality Materials",
-                  description: "Premium SupaPoint flexible pointing compound designed for Australian conditions."
-                },
-                {
-                  icon: <CheckCircle className="h-8 w-8 text-primary" />,
-                  title: "Detailed Photos",
-                  description: "Before, during, and after photos documenting all work completed."
-                }
-              ].map((service, index) => (
-                <Card key={index} className="text-center">
-                  <CardHeader>
-                    <div className="mx-auto mb-4 p-3 bg-primary/10 rounded-full w-fit">
-                      {service.icon}
-                    </div>
-                    <CardTitle className="text-xl">{service.title}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription>{service.description}</CardDescription>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Why Repoint Section */}
-        <section className="py-16 bg-muted/50">
-          <div className="container mx-auto px-4">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-              <div>
-                <h2 className="text-3xl font-bold mb-6">Why Roof Repointing is Essential</h2>
-                <div className="space-y-6">
-                  {[
-                    {
-                      icon: <AlertTriangle className="h-6 w-6 text-destructive" />,
-                      title: "Prevent Water Damage",
-                      description: "Cracked mortar allows water to penetrate, causing ceiling damage and mold issues."
-                    },
-                    {
-                      icon: <Shield className="h-6 w-6 text-primary" />,
-                      title: "Extend Roof Life",
-                      description: "Proper pointing protects tiles and timber, adding 15+ years to your roof's lifespan."
-                    },
-                    {
-                      icon: <Clock className="h-6 w-6 text-primary" />,
-                      title: "Cost-Effective Solution",
-                      description: "Repointing costs far less than full roof replacement while solving leak issues."
-                    }
-                  ].map((item, index) => (
-                    <div key={index} className="flex gap-4">
-                      <div className="flex-shrink-0 p-2 bg-background rounded-lg">
-                        {item.icon}
-                      </div>
-                      <div>
-                        <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
-                        <p className="text-muted-foreground">{item.description}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="relative">
-                <OptimizedImage
-                  src="/lovable-uploads/59ae7b51-3197-43f9-9e4e-3ac96bc90d97.png"
-                  alt="Before and after roof repointing comparison"
-                  className="rounded-lg shadow-xl"
-                  width={600}
-                  height={450}
-                />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* FAQ Section */}
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Frequently Asked Questions</h2>
-              <p className="text-xl text-muted-foreground">
-                Common questions about roof repointing services
-              </p>
-            </div>
-
-            <div className="max-w-4xl mx-auto">
-              <Accordion type="single" collapsible className="w-full">
-                <AccordionItem value="item-1">
-                  <AccordionTrigger>How long does roof repointing take?</AccordionTrigger>
-                  <AccordionContent>
-                    Most roof repointing jobs take 1-3 days depending on the roof size and extent of work needed. 
-                    We'll provide an accurate timeline during the free assessment.
-                  </AccordionContent>
-                </AccordionItem>
-
-                <AccordionItem value="item-2">
-                  <AccordionTrigger>What's the difference between bedding and pointing?</AccordionTrigger>
-                  <AccordionContent>
-                    Bedding is the mortar that sits under ridge caps and tiles, while pointing is the outer layer 
-                    that seals and protects the bedding. Both work together to keep water out.
-                  </AccordionContent>
-                </AccordionItem>
-
-                <AccordionItem value="item-3">
-                  <AccordionTrigger>Do you offer a warranty on repointing work?</AccordionTrigger>
-                  <AccordionContent>
-                    Yes, we provide a 10-year workmanship warranty on all repointing work using premium SupaPoint materials. 
-                    This covers any defects in workmanship or material failure.
-                  </AccordionContent>
-                </AccordionItem>
-
-                <AccordionItem value="item-4">
-                  <AccordionTrigger>How do I know if my roof needs repointing?</AccordionTrigger>
-                  <AccordionContent>
-                    Signs include: cracked or missing mortar around ridge caps, water stains on ceilings, 
-                    loose tiles, or visible gaps in pointing. We offer free assessments to determine if repointing is needed.
-                  </AccordionContent>
-                </AccordionItem>
-
-                <AccordionItem value="item-5">
-                  <AccordionTrigger>What areas do you service for repointing?</AccordionTrigger>
-                  <AccordionContent>
-                    We service all of Southeast Melbourne within 50km of Clyde North, including Berwick, Officer, 
-                    Pakenham, Cranbourne, Narre Warren, and surrounding suburbs.
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </div>
-          </div>
-        </section>
-
-        {/* Contact CTA Section */}
-        <section className="py-16 bg-primary/5">
-          <div className="container mx-auto px-4">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">Ready to Fix Your Roof Pointing?</h2>
-              <p className="text-xl text-muted-foreground mb-8">
-                Get a free assessment and detailed quote. No obligation, honest advice only.
-              </p>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
-              <div className="space-y-6">
-                <div className="text-center lg:text-left">
-                  <h3 className="text-2xl font-bold mb-4">Call Kaidyn Directly</h3>
-                  <p className="text-muted-foreground mb-6">
-                    Speak directly with the owner for honest advice and accurate pricing. 
-                    No call centers or sales pressure.
-                  </p>
-                  
-                  <div className="space-y-4">
-                    <Button asChild size="lg" className="w-full sm:w-auto">
-                      <a href="tel:0435900709" className="flex items-center gap-2 justify-center">
-                        <Phone className="h-5 w-5" />
-                        0435 900 709
-                      </a>
-                    </Button>
-                    
-                    <div className="text-sm text-muted-foreground">
-                      <p>📍 Based in Clyde North, VIC</p>
-                      <p>📧 callkaidsroofing@outlook.com</p>
-                      <p>🏢 ABN: 39475055075</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Get Your Free Roof Assessment</CardTitle>
-                    <CardDescription>
-                      Complete the form below and we'll call you back within 12 hours
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <EnhancedContactForm />
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-    </>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">CTAs</h2>
+        <ServiceCtas ctas={ctas} />
+      </section>
+    </ServicePageLayout>
   );
 };
 

--- a/src/pages/services/RoofRestoration.tsx
+++ b/src/pages/services/RoofRestoration.tsx
@@ -1,384 +1,116 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Phone, CheckCircle, Clock, Shield, MapPin, DollarSign, Home, AlertTriangle } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { OptimizedBackgroundSection } from '@/components/OptimizedBackgroundSection';
-import ServiceSpecificForm from '@/components/ServiceSpecificForm';
-import { SEOHead } from '@/components/SEOHead';
-import { StructuredData } from '@/components/StructuredData';
+import { CheckCircle2 } from 'lucide-react';
+import { ServicePageLayout } from '@/components/services/service-page-layout';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
+
+const ctas: ServiceCta[] = [
+  { label: 'Book Your Free Roof Health Check', href: '/book', variant: 'primary' },
+  { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
+];
+
+const benefits = [
+  'Stops leaks and prevents costly water damage',
+  'Premium Dulux membranes designed for Melbourne weather',
+  'Fresh new look that boosts street appeal and property value',
+  'Includes ridge rebedding and repointing',
+  '500+ happy customers, 4.9/5 star rating',
+  'Backed by our 10-year workmanship warranty'
+];
+
+const process = [
+  'Free roof health check and fixed quote',
+  'Repairs and ridge rebedding & repointing',
+  'Full pressure clean and prep',
+  'Primer + two-coat Dulux membrane',
+  'Quality assurance and photos delivered'
+];
+
+const serviceAreas = [
+  'Clyde North',
+  'Pakenham',
+  'Narre Warren',
+  'Cranbourne',
+  'Berwick',
+  'Frankston',
+  'Dandenong',
+  'Brighton',
+  'Suburbs within 50 km'
+];
+
+const relatedLinks = [
+  { label: 'Learn about Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
+  { label: 'View Roof Pressure Cleaning', href: '/services/roof-pressure-cleaning' },
+  { label: 'Read about our 10-Year Warranty', href: '/warranty' }
+];
 
 const RoofRestoration = () => {
-  const restorationSteps = [
-    {
-      step: "1",
-      title: "Honest Assessment First",
-      description: "I'll climb up and check every inch of your roof. If it's too far gone, I'll tell you straight—don't waste money on restoration if replacement is the smarter choice.",
-      details: [
-        "Structural integrity of the roof frame",
-        "Tile condition and how many need replacing",
-        "Ridge capping and pointing condition", 
-        "Valley irons and flashing systems",
-        "Overall feasibility of restoration vs replacement"
-      ]
-    },
-    {
-      step: "2", 
-      title: "High-Pressure Clean",
-      description: "Strip off years of dirt, moss, and grime with professional high-pressure equipment. This isn't a garden hose job—we're talking serious cleaning gear that brings tiles back to their original colour.",
-      details: []
-    },
-    {
-      step: "3",
-      title: "Fix Everything That's Broken", 
-      description: "Replace cracked tiles, re-bed loose ridge caps, fix valley irons, repair flashings. No point painting over problems—fix them properly first.",
-      details: [
-        "Tile replacement with perfect colour matches",
-        "Ridge capping re-bedding using quality mortar", 
-        "Valley iron repairs or replacement if needed",
-        "Flashing adjustments around chimneys and vents"
-      ]
-    },
-    {
-      step: "4",
-      title: "Premium Primer and Membrane",
-      description: "Apply industrial-grade primer, then two thick coats of premium membrane. This isn't paint—it's a protective coating designed specifically for Australian roofs.",
-      details: [
-        "15+ year lifespan on the coating system",
-        "Waterproof seal that stops leaks before they start",
-        "UV protection preventing further fading", 
-        "Energy savings through reflective properties"
-      ]
-    }
-  ];
-
-  const perfectCandidates = [
-    "Structurally sound roofs that just look tired",
-    "15-30 year old homes in suburbs like Frankston, Narre Warren, Berwick",
-    "Heritage homes where replacement isn't practical", 
-    "Budget-conscious owners who want maximum bang for buck"
-  ];
-
-  const whenToReplace = [
-    "Severely damaged structure with multiple leaks",
-    "Asbestos roofing that needs professional removal",
-    "Roofs over 40 years old with major structural issues",
-    "Extensive storm damage where replacement is more cost-effective"
-  ];
-
-  const suburbConsiderations = [
-    {
-      category: "Established Suburbs (Frankston, Narre Warren)",
-      description: "These areas have lots of 20-30 year old homes perfect for restoration.",
-      issues: [
-        "Faded terracotta tiles from UV exposure",
-        "Moss growth from mature tree coverage", 
-        "Minor storm damage accumulated over years",
-        "Original coatings that have reached end of life"
-      ]
-    },
-    {
-      category: "Growth Corridors (Clyde North, Berwick, Officer)",
-      description: "Newer homes (10-20 years) often need preventative restoration.",
-      issues: [
-        "Early maintenance to extend roof life",
-        "Colour updates to match renovations",
-        "Protective coatings before major problems develop",
-        "Investment protection for growing property values"
-      ]
-    },
-    {
-      category: "Heritage Areas (Hawthorn, Kew, Toorak)",
-      description: "Special considerations for character homes.",
-      issues: [
-        "Heritage-compliant materials and colours",
-        "Traditional techniques where required",
-        "Council approval assistance if needed",
-        "Character preservation with modern protection"
-      ]
-    }
-  ];
-
   return (
-    <div className="min-h-screen">
-      <SEOHead
-        title="Roof Restorations Clyde North | Call Kaids Roofing SE Melbourne"
-        description="Bring your roof back to life with professional restorations. Serving Clyde North, Cranbourne, Berwick & surrounds. Honest quotes, lasting results."
-        keywords="roof restoration Clyde North, roof restoration Cranbourne, roof restoration Berwick, Call Kaids Roofing"
-      />
-      <StructuredData 
-        type="service" 
-        serviceName="Roof Restoration"
-        serviceDescription="Complete roof overhaul with high-pressure clean, repairs, and premium membrane coating system"
-        pageUrl="https://callkaidsroofing.com.au/services/roof-restoration"
-      />
-      {/* Hero Section */}
-      <OptimizedBackgroundSection
-        backgroundImage="/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d.png"
-        className="py-20 text-white"
-        gradient="linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.4))"
-      >
-        <div className="container mx-auto px-4 text-center relative z-10">
-          <h1 className="text-4xl md:text-5xl font-bold mb-6">
-            Roof Restoration Melbourne
-          </h1>
-          <p className="text-xl mb-8 max-w-3xl mx-auto opacity-90">
-            Transform your roof for 60-70% less than replacement. 10-year warranty included.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild variant="secondary" size="xl">
-              <a href="tel:0435900709">
-                <Phone className="mr-2 h-5 w-5" />
-                Call 0435 900 709
-              </a>
-            </Button>
-            <Button asChild variant="outline" size="xl" className="bg-white/10 border-white/20 text-white hover:bg-white/20">
-              <Link to="/book">Get Free Quote</Link>
-            </Button>
-          </div>
-        </div>
-      </OptimizedBackgroundSection>
-
-      {/* Service Form */}
-      <ServiceSpecificForm 
-        serviceName="Roof Restoration"
-        serviceDescription="Complete roof overhaul with high-pressure clean, repairs, and premium membrane coating system"
-        ctaText="Get Free Restoration Quote"
-      />
-
-      {/* Process Section */}
-      <section className="py-16 bg-muted/20">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">My Restoration Process</h2>
-          <div className="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-            {restorationSteps.map((step, index) => (
-              <Card key={index} className="h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3 mb-2">
-                    <Badge variant="secondary" className="text-lg px-3 py-1 min-w-[40px] text-center">
-                      {step.step}
-                    </Badge>
-                  </div>
-                  <CardTitle>{step.title}</CardTitle>
-                  <CardDescription>{step.description}</CardDescription>
-                </CardHeader>
-                {step.details.length > 0 && (
-                  <CardContent>
-                    <ul className="space-y-2">
-                      {step.details.map((detail, detailIndex) => (
-                        <li key={detailIndex} className="flex items-start gap-2">
-                          <CheckCircle className="h-4 w-4 text-primary mt-0.5 flex-shrink-0" />
-                          <span className="text-sm">{detail}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                )}
-              </Card>
-            ))}
-          </div>
-        </div>
+    <ServicePageLayout
+      seo={{
+        title: 'Full Roof Restoration Clyde North & SE Melbourne – 10-Year Warranty | Call Kaids Roofing',
+        description:
+          'Restore your roof with cleaning, rebedding, repointing, and Dulux membrane coating. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and photo proof.'
+      }}
+      hero={{
+        title: 'Full Roof Restorations',
+        subtitle:
+          'Protect your home and add years of life. Full roof restorations in Clyde North & SE Melbourne with a 10-year workmanship warranty, premium Dulux membranes, and photo proof on completion.'
+      }}
+      ctas={ctas}
+      trustSignals={['500+ happy customers', '4.9/5 star rating', 'Fully licensed & insured']}
+      relatedLinks={relatedLinks}
+      structuredData={{
+        serviceName: 'Full Roof Restoration',
+        serviceDescription:
+          'Cleaning, ridge rebedding and repointing, and Dulux membrane coating with a 10-year workmanship warranty across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/roof-restoration'
+      }}
+    >
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Benefits</h2>
+        <ul className="space-y-3 text-muted-foreground">
+          {benefits.map((benefit) => (
+            <li key={benefit} className="flex items-start gap-3">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
       </section>
 
-      {/* When to Choose Restoration vs Replacement */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Is Restoration Right for Your Roof?</h2>
-          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-            <Card className="border-green-200 bg-green-50/50">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-green-700">
-                  <CheckCircle className="h-5 w-5" />
-                  Perfect Candidates
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3">
-                  {perfectCandidates.map((candidate, index) => (
-                    <li key={index} className="flex items-start gap-2">
-                      <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
-                      <span className="text-sm">{candidate}</span>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-
-            <Card className="border-orange-200 bg-orange-50/50">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-orange-700">
-                  <AlertTriangle className="h-5 w-5" />
-                  When I'll Tell You to Replace Instead
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground mb-4">
-                  I won't take your money if restoration isn't the right choice:
-                </p>
-                <ul className="space-y-3">
-                  {whenToReplace.map((reason, index) => (
-                    <li key={index} className="flex items-start gap-2">
-                      <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5 flex-shrink-0" />
-                      <span className="text-sm">{reason}</span>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Process</h2>
+        <ol className="space-y-4 text-muted-foreground">
+          {process.map((step, index) => (
+            <li key={step} className="flex gap-4">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="pt-2 text-base">{step}</span>
+            </li>
+          ))}
+        </ol>
       </section>
 
-      {/* Suburb Considerations */}
-      <section className="py-16 bg-muted/20">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Suburb-Specific Considerations</h2>
-          <div className="grid lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            {suburbConsiderations.map((suburb, index) => (
-              <Card key={index}>
-                <CardHeader>
-                  <CardTitle className="text-lg">{suburb.category}</CardTitle>
-                  <CardDescription>{suburb.description}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2">
-                    {suburb.issues.map((issue, issueIndex) => (
-                      <li key={issueIndex} className="flex items-start gap-2">
-                        <span className="text-primary mt-1">•</span>
-                        <span className="text-sm">{issue}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Investment and Pricing */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Investment and Value</h2>
-          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <DollarSign className="h-5 w-5 text-primary" />
-                  Typical Costs
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Small homes (150-200m²)</span>
-                  <Badge variant="outline">$6,000 - $9,000</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Standard homes (200-300m²)</span>
-                  <Badge variant="outline">$9,000 - $15,000</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Large homes (300m²+)</span>
-                  <Badge variant="outline">$15,000 - $22,000</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2">
-                  <span>Heritage/complex roofs</span>
-                  <Badge variant="outline">$22,000 - $30,000</Badge>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Home className="h-5 w-5 text-primary" />
-                  Return on Investment
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3">
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-primary mt-0.5" />
-                    <span className="text-sm">Property value increase: 2-4% typical</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-primary mt-0.5" />
-                    <span className="text-sm">Energy savings: $200-400 annually</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-primary mt-0.5" />
-                    <span className="text-sm">Maintenance avoidance: Prevents $5,000+ in repairs</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-primary mt-0.5" />
-                    <span className="text-sm">Extended roof life: 15-20 years additional lifespan</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle className="h-4 w-4 text-primary mt-0.5" />
-                    <span className="text-sm">Compare to replacement: 60% cost savings</span>
-                  </li>
-                </ul>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
-
-      {/* 10-Year Warranty */}
-      <section className="py-16 bg-primary text-primary-foreground">
-        <div className="container mx-auto px-4 text-center">
-          <div className="max-w-4xl mx-auto">
-            <h2 className="text-3xl font-bold mb-6">What You Get with My Restoration</h2>
-            <div className="grid md:grid-cols-2 gap-8 mb-8">
-              <Card className="bg-white/10 border-white/20 text-white">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Shield className="h-5 w-5" />
-                    10-Year Warranty
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2 text-left">
-                    <li>• Membrane performance against cracking or peeling</li>
-                    <li>• Leak-free guarantee on all repair work</li>
-                    <li>• Colour stability within normal parameters</li>
-                    <li>• Workmanship quality on all aspects</li>
-                  </ul>
-                </CardContent>
-              </Card>
-
-              <Card className="bg-white/10 border-white/20 text-white">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <CheckCircle className="h-5 w-5" />
-                    Premium Materials Only
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2 text-left">
-                    <li>• Supa Point or Premier Roof Coatings premium membranes</li>
-                    <li>• Climate-specific primers and sealers</li>
-                    <li>• UV-resistant RGL or Shield Coat colour systems</li>
-                    <li>• Industrial-grade coatings that move with your roof</li>
-                  </ul>
-                </CardContent>
-              </Card>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Service Areas</h2>
+        <p className="mb-4 text-muted-foreground">
+          Serving Clyde North, Pakenham, Narre Warren, Cranbourne, Berwick, Frankston, Dandenong, Brighton, and suburbs within 50 km.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {serviceAreas.map((area) => (
+            <div key={area} className="rounded-2xl border border-primary/10 bg-background p-4 text-sm font-medium text-foreground shadow-sm">
+              {area}
             </div>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button asChild variant="secondary" size="xl">
-                <a href="tel:0435900709">
-                  <Phone className="mr-2 h-5 w-5" />
-                  Call 0435 900 709
-                </a>
-              </Button>
-              <Button asChild variant="outline" size="xl" className="bg-white/10 border-white/20 text-white hover:bg-white/20">
-                <Link to="/contact">Get Free Quote</Link>
-              </Button>
-            </div>
-          </div>
+          ))}
         </div>
       </section>
-    </div>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">CTAs</h2>
+        <ServiceCtas ctas={ctas} />
+      </section>
+    </ServicePageLayout>
   );
 };
 

--- a/src/pages/services/ValleyIronReplacement.tsx
+++ b/src/pages/services/ValleyIronReplacement.tsx
@@ -1,433 +1,134 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Phone, CheckCircle, Clock, Shield, MapPin, AlertTriangle, Wrench, DollarSign } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { OptimizedBackgroundSection } from '@/components/OptimizedBackgroundSection';
+import { CheckCircle2 } from 'lucide-react';
+import { ServicePageLayout } from '@/components/services/service-page-layout';
+import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
+import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
+
+const ctas: ServiceCta[] = [
+  { label: 'Book Now', href: '/book', variant: 'primary' },
+  { label: `Call Now – ${COMPANY_PHONE_DISPLAY}`, href: COMPANY_PHONE_TEL, variant: 'secondary' }
+];
+
+const whatsIncluded = [
+  'Removal of old or rusted valley irons',
+  'Inspection of valley boards and surrounding tiles',
+  'Installation of new valley irons and breathable sarking',
+  'Bedding and pointing around the valley edges',
+  'Photo evidence on completion'
+];
+
+const benefits = [
+  'Ensures proper water runoff at the roof valleys',
+  'Prevents leaks and water damage',
+  'Extends the life of your roof',
+  'Uses compliant materials and Dulux membranes where applicable'
+];
+
+const process = [
+  'Free roof health check and fixed quote',
+  'Remove old valley irons and assess valley boards',
+  'Install new valley irons with breathable sarking',
+  'Apply bedding and pointing',
+  'Quality assurance and photos delivered'
+];
+
+const serviceAreas = [
+  'Clyde North',
+  'Pakenham',
+  'Narre Warren',
+  'Cranbourne',
+  'Berwick',
+  'Frankston',
+  'Dandenong',
+  'Brighton',
+  'Suburbs within 50 km'
+];
+
+const relatedLinks = [
+  { label: 'Learn about Leak Repairs', href: '/services/leak-repairs' },
+  { label: 'View Ridge Rebedding & Repointing', href: '/services/roof-repointing' },
+  { label: 'Book a Free Roof Health Check', href: '/services/health-check' }
+];
 
 const ValleyIronReplacement = () => {
-  const problemSigns = [
-    "Rust stains on valley iron or surrounding tiles",
-    "Water leaks during heavy rain in valley areas",
-    "Visible holes or corrosion in valley iron",
-    "Separation between valley iron and roof tiles",
-    "Interior water stains near valley areas",
-    "Moss or debris accumulation in valleys"
-  ];
-
-  const replacementProcess = [
-    {
-      step: "1",
-      title: "Thorough Inspection",
-      description: "Comprehensive assessment of all valley irons and surrounding roof structure.",
-      details: [
-        "Check for rust, corrosion, and structural damage",
-        "Assess water flow and drainage patterns",
-        "Examine tile condition around valleys",
-        "Identify any structural issues requiring attention"
-      ]
-    },
-    {
-      step: "2",
-      title: "Safe Removal",
-      description: "Careful removal of old valley irons without damaging surrounding tiles.",
-      details: [
-        "Professional tile lifting techniques",
-        "Protect surrounding roof areas",
-        "Document any additional issues found",
-        "Prepare surface for new installation"
-      ]
-    },
-    {
-      step: "3",
-      title: "Quality Installation",
-      description: "Install premium valley iron with proper flashing and waterproofing.",
-      details: [
-        "High-grade Colorbond or stainless steel",
-        "Proper fall for optimal water flow",
-        "Waterproof membrane installation",
-        "Secure tile replacement and pointing"
-      ]
-    },
-    {
-      step: "4",
-      title: "Testing & Warranty",
-      description: "Comprehensive water testing and 10-year warranty on workmanship.",
-      details: [
-        "Water flow testing during installation",
-        "Quality inspection of all joints",
-        "10-year warranty documentation",
-        "Maintenance recommendations provided"
-      ]
-    }
-  ];
-
-  const materialOptions = [
-    {
-      material: "Colorbond Steel",
-      benefits: ["Colour-matched to roof", "20+ year lifespan", "Australian made", "Thermal expansion compatible"],
-      cost: "$45-65/metre",
-      recommended: "Most homes"
-    },
-    {
-      material: "Stainless Steel", 
-      benefits: ["Superior corrosion resistance", "30+ year lifespan", "Premium appearance", "Maintenance-free"],
-      cost: "$65-85/metre",
-      recommended: "Heritage/premium homes"
-    },
-    {
-      material: "Zincalume",
-      benefits: ["Cost-effective option", "Good corrosion resistance", "15+ year lifespan", "Paintable surface"],
-      cost: "$35-45/metre", 
-      recommended: "Budget-conscious owners"
-    }
-  ];
-
-  const whyValleyIronsFail = [
-    {
-      cause: "Age and Corrosion",
-      description: "Original valley irons from 20+ years ago often used lower-grade materials that deteriorate faster in Melbourne's climate."
-    },
-    {
-      cause: "Poor Installation",
-      description: "Inadequate fall, incorrect flashing, or poor waterproofing during original installation leads to premature failure."
-    },
-    {
-      cause: "Debris Accumulation",
-      description: "Leaves and debris in valleys trap moisture against the iron, accelerating corrosion and creating leak points."
-    },
-    {
-      cause: "Thermal Movement",
-      description: "Expansion and contraction in Melbourne's temperature extremes can cause separation and joint failure."
-    }
-  ];
-
   return (
-    <div className="min-h-screen">
-      {/* Hero Section */}
-      <OptimizedBackgroundSection
-        backgroundImage="/lovable-uploads/b583ddb3-be15-4d62-b3fe-1d5a4ed4cd2a.png"
-        gradient="linear-gradient(130deg, rgba(12,74,110,0.9), rgba(37,99,235,0.82))"
-        className="py-20 text-white"
-        imageAlt="Replacing rusted valley iron in Melbourne"
-        sizes="(max-width: 1024px) 100vw, 1200px"
-      >
-        <div className="container mx-auto px-4 text-center relative z-10">
-          <h1 className="text-4xl md:text-5xl font-bold mb-6">
-            Valley Iron Replacement: Stop Hidden Leaks Before They Destroy Your Home
-          </h1>
-          <p className="text-xl mb-8 max-w-3xl mx-auto opacity-90">
-            Rusted valley irons are a common problem in older homes and a major cause of leaks. Specialist replacement service
-            using premium materials with 10-year warranty protection.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild variant="secondary" size="xl">
-              <a href="tel:0435900709">
-                <Phone className="mr-2 h-5 w-5" />
-                Call 0435 900 709
-              </a>
-            </Button>
-            <Button asChild variant="outline" size="xl" className="bg-white/10 border-white/20 text-white hover:bg-white/20">
-              <Link to="/book">Get Free Quote</Link>
-            </Button>
-          </div>
-        </div>
-      </OptimizedBackgroundSection>
+    <ServicePageLayout
+      seo={{
+        title: 'Valley Iron Replacement Clyde North – Prevent Leaks | Call Kaids Roofing',
+        description:
+          'Replace rusted or damaged valley irons to ensure proper water runoff. Serving Clyde North & SE Melbourne with new sarking, secure edges, and a 10-year workmanship warranty.'
+      }}
+      hero={{
+        title: 'Valley Iron Replacement',
+        subtitle:
+          'Protect your roof from leaks at the valleys. Professional valley iron replacements in Clyde North & SE Melbourne with photo proof and a 10-year warranty.'
+      }}
+      ctas={ctas}
+      trustSignals={['500+ happy customers', '4.9/5 stars on local reviews', 'Fully licensed & insured']}
+      relatedLinks={relatedLinks}
+      structuredData={{
+        serviceName: 'Valley Iron Replacement',
+        serviceDescription:
+          'Valley iron removal, sarking replacement, and new bedding with a 10-year workmanship warranty across Clyde North and Southeast Melbourne.',
+        pageUrl: 'https://callkaidsroofing.com.au/services/valley-iron-replacement'
+      }}
+    >
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">What’s Included</h2>
+        <ul className="space-y-3 text-muted-foreground">
+          {whatsIncluded.map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
-      {/* Why Valley Irons Fail */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Why Valley Irons Fail (And Why It's So Dangerous)</h2>
-          <div className="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-            <Card className="border-orange-200 bg-orange-50/50">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-orange-700">
-                  <AlertTriangle className="h-5 w-5" />
-                  The Hidden Danger
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground mb-4">
-                  Valley irons channel massive amounts of water from multiple roof planes into a concentrated flow. 
-                  When they fail, water goes directly into your roof cavity, often causing extensive damage before you even notice.
-                </p>
-                <p className="font-semibold text-orange-700">
-                  A failed valley iron can cause thousands of dollars in structural damage, insulation replacement, 
-                  and mould remediation - all hidden until it's too late.
-                </p>
-              </CardContent>
-            </Card>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Benefits</h2>
+        <ul className="space-y-3 text-muted-foreground">
+          {benefits.map((benefit) => (
+            <li key={benefit} className="flex items-start gap-3">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <CheckCircle className="h-5 w-5 text-primary" />
-                  Signs You Need Valley Iron Replacement
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3">
-                  {problemSigns.map((sign, index) => (
-                    <li key={index} className="flex items-start gap-2">
-                      <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5 flex-shrink-0" />
-                      <span className="text-sm">{sign}</span>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </div>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Process</h2>
+        <ol className="space-y-4 text-muted-foreground">
+          {process.map((step, index) => (
+            <li key={step} className="flex gap-4">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-base font-semibold text-primary">
+                {index + 1}
+              </span>
+              <span className="pt-2 text-base">{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">Service Areas</h2>
+        <p className="mb-4 text-muted-foreground">
+          Serving Clyde North, Pakenham, Narre Warren, Cranbourne, Berwick, Frankston, Dandenong, Brighton, and suburbs within 50 km.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {serviceAreas.map((area) => (
+            <div key={area} className="rounded-2xl border border-primary/10 bg-background p-4 text-sm font-medium text-foreground shadow-sm">
+              {area}
+            </div>
+          ))}
         </div>
       </section>
 
-      {/* Common Causes of Failure */}
-      <section className="py-16 bg-muted/20">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Common Causes of Valley Iron Failure</h2>
-          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-            {whyValleyIronsFail.map((cause, index) => (
-              <Card key={index}>
-                <CardHeader>
-                  <CardTitle className="text-lg">{cause.cause}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">{cause.description}</p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold tracking-tight">CTAs</h2>
+        <ServiceCtas ctas={ctas} />
       </section>
-
-      {/* Replacement Process */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">My Valley Iron Replacement Process</h2>
-          <div className="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-            {replacementProcess.map((step, index) => (
-              <Card key={index} className="h-full">
-                <CardHeader>
-                  <div className="flex items-center gap-3 mb-2">
-                    <Badge variant="secondary" className="text-lg px-3 py-1 min-w-[40px] text-center">
-                      {step.step}
-                    </Badge>
-                  </div>
-                  <CardTitle>{step.title}</CardTitle>
-                  <CardDescription>{step.description}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2">
-                    {step.details.map((detail, detailIndex) => (
-                      <li key={detailIndex} className="flex items-start gap-2">
-                        <CheckCircle className="h-4 w-4 text-primary mt-0.5 flex-shrink-0" />
-                        <span className="text-sm">{detail}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Material Options */}
-      <section className="py-16 bg-muted/20">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Premium Material Options</h2>
-          <div className="grid lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            {materialOptions.map((option, index) => (
-              <Card key={index} className={option.material === "Colorbond Steel" ? "border-primary bg-primary/5" : ""}>
-                <CardHeader>
-                  <div className="flex items-start justify-between">
-                    <CardTitle className="text-lg">{option.material}</CardTitle>
-                    <Badge variant="outline">{option.cost}</Badge>
-                  </div>
-                  {option.material === "Colorbond Steel" && (
-                    <Badge variant="default" className="w-fit">Most Popular</Badge>
-                  )}
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2 mb-4">
-                    {option.benefits.map((benefit, benefitIndex) => (
-                      <li key={benefitIndex} className="flex items-start gap-2">
-                        <CheckCircle className="h-4 w-4 text-primary mt-0.5 flex-shrink-0" />
-                        <span className="text-sm">{benefit}</span>
-                      </li>
-                    ))}
-                  </ul>
-                  <p className="text-xs text-muted-foreground">
-                    <strong>Best for:</strong> {option.recommended}
-                  </p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Investment and Costs */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Investment in Valley Iron Replacement</h2>
-          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <DollarSign className="h-5 w-5 text-primary" />
-                  Typical Project Costs
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Single valley (3-5m)</span>
-                  <Badge variant="outline">$450-700</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Two valleys (6-10m)</span>
-                  <Badge variant="outline">$900-1,400</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2 border-b">
-                  <span>Multiple valleys (15-25m)</span>
-                  <Badge variant="outline">$2,000-3,500</Badge>
-                </div>
-                <div className="flex justify-between items-center py-2">
-                  <span>Complex/heritage homes</span>
-                  <Badge variant="outline">$2,500-4,000+</Badge>
-                </div>
-                <p className="text-xs text-muted-foreground mt-4">
-                  *Includes removal, disposal, premium materials, and 10-year warranty
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Shield className="h-5 w-5 text-primary" />
-                  Cost of NOT Replacing
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-3">
-                  <li className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5" />
-                    <span className="text-sm">Structural damage: $3,000-10,000+</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5" />
-                    <span className="text-sm">Insulation replacement: $1,500-3,000</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5" />
-                    <span className="text-sm">Mould remediation: $2,000-6,000</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5" />
-                    <span className="text-sm">Interior repairs: $2,000-8,000</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <AlertTriangle className="h-4 w-4 text-orange-600 mt-0.5" />
-                    <span className="text-sm">Temporary accommodation costs</span>
-                  </li>
-                </ul>
-                <div className="bg-orange-50 p-4 rounded-lg mt-4">
-                  <p className="text-sm font-semibold text-orange-800">
-                    Prevention is always cheaper than repair. Valley iron replacement now 
-                    can save tens of thousands in water damage later.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
-
-      {/* Why Choose Us */}
-      <section className="py-16 bg-muted/20">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-12 text-center">Why Choose Call Kaids Roofing for Valley Iron Replacement</h2>
-          <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Wrench className="h-5 w-5 text-primary" />
-                  Specialist Expertise
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2 text-sm">
-                  <li>• Valley iron replacement specialist</li>
-                  <li>• 25+ years of combined roofing experience with all roof types and ages</li>
-                  <li>• Proper fall calculation for optimal drainage</li>
-                  <li>• Heritage and council compliance knowledge</li>
-                </ul>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Shield className="h-5 w-5 text-primary" />
-                  Premium Materials Only
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2 text-sm">
-                  <li>• Colorbond steel - 20+ year lifespan</li>
-                  <li>• Stainless steel for premium applications</li>
-                  <li>• Quality flashing and waterproof membranes</li>
-                  <li>• All materials backed by manufacturer warranty</li>
-                </ul>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <CheckCircle className="h-5 w-5 text-primary" />
-                  Complete Peace of Mind
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2 text-sm">
-                  <li>• 10-year warranty on all workmanship</li>
-                  <li>• Comprehensive insurance coverage</li>
-                  <li>• Water testing before completion</li>
-                  <li>• Local reputation you can trust</li>
-                </ul>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
-
-      {/* Call to Action */}
-      <section className="py-16 bg-primary text-primary-foreground">
-        <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold mb-6">Don't Let Failed Valley Irons Destroy Your Home</h2>
-          <p className="text-xl mb-8 max-w-3xl mx-auto opacity-90">
-            Valley iron failure causes some of the most expensive and hidden water damage in homes. 
-            Get yours inspected and replaced before disaster strikes.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild variant="secondary" size="xl">
-              <a href="tel:0435900709">
-                <Phone className="mr-2 h-5 w-5" />
-                Call Kaidyn: 0435 900 709
-              </a>
-            </Button>
-            <Button asChild variant="outline" size="xl" className="bg-white/10 border-white/20 text-white hover:bg-white/20">
-              <Link to="/book">Get Free Inspection</Link>
-            </Button>
-          </div>
-          <div className="mt-8 space-y-2 text-sm opacity-75">
-            <p>Free valley iron inspection with any roofing quote</p>
-            <p>Serving Southeast Melbourne within 50km of Clyde North</p>
-          </div>
-        </div>
-      </section>
-    </div>
+    </ServicePageLayout>
   );
 };
 

--- a/supabase/functions/admin-security-notification/index.ts
+++ b/supabase/functions/admin-security-notification/index.ts
@@ -13,7 +13,7 @@ interface AdminSecurityEvent {
   event_type: string;
   user_id: string;
   user_email: string;
-  event_details: any;
+  event_details: Record<string, unknown> | null;
   timestamp: string;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,4 +49,7 @@ export default defineConfig(({ mode }) => ({
   css: {
     devSourcemap: true,
   },
+  test: {
+    environment: 'jsdom',
+  },
 }));


### PR DESCRIPTION
## Summary
- add shared service layout/CTA utilities and centralise company contact constants
- rebuild the services index, create bundle deals page, and rewrite service pages with new copy and structure
- wire up new routes/navigation, add focused vitest coverage, and harden supabase event typing for lint compliance

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d423625a68832098722f7c9dae27cf