### PR TITLE
fix: tighten canonical SEO signals

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,12 @@
+# Force HTTPS + non-www
+http://callkaidsroofing.com.au/*    https://callkaidsroofing.com.au/:splat 301!
+http://www.callkaidsroofing.com.au/* https://callkaidsroofing.com.au/:splat 301!
+https://www.callkaidsroofing.com.au/* https://callkaidsroofing.com.au/:splat 301!
+
+# Old aliases to canonical routes
+/roof-restoration      /services/roof-restoration 301
+/roof-painting         /services/roof-painting 301
+/roof-repairs          /services/roof-repairs 301
+/gutter-cleaning       /services/gutter-cleaning 301
+/valley-iron-replacement /services/valley-iron-replacement 301
+/*/  /:splat 301!

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,27 +1,8 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
 Allow: /
-Allow: /services/
-Allow: /about
-Allow: /contact
-Allow: /emergency
-Allow: /warranty
+
+# Do not index system/private areas
 Disallow: /admin/
 Disallow: /private/
 
-# Sitemaps
 Sitemap: https://callkaidsroofing.com.au/sitemap.xml
-
-# Crawl delay for respectful crawling
-Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,182 +2,68 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://callkaidsroofing.com.au/</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-09-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/roof-painting-clyde-north</loc>
-    <lastmod>2025-09-21</lastmod>
+    <loc>https://callkaidsroofing.com.au/services/roof-restoration</loc>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.95</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/roof-painting-cranbourne</loc>
-    <lastmod>2025-09-21</lastmod>
+    <loc>https://callkaidsroofing.com.au/services/roof-painting</loc>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.90</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/roof-painting-pakenham</loc>
-    <lastmod>2025-09-21</lastmod>
+    <loc>https://callkaidsroofing.com.au/services/roof-repairs</loc>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.90</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration-berwick</loc>
-    <lastmod>2025-09-21</lastmod>
+    <loc>https://callkaidsroofing.com.au/services/gutter-cleaning</loc>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration-clyde-north</loc>
-    <lastmod>2025-09-21</lastmod>
+    <loc>https://callkaidsroofing.com.au/services/valley-iron-replacement</loc>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration-cranbourne</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration-mount-eliza</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration-pakenham</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/gutter-cleaning</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/leak-detection</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-painting</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-repairs</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-repointing</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/roof-restoration</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/tile-replacement</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/valley-iron-replacement</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.85</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/about</loc>
-    <lastmod>2025-09-21</lastmod>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/blog</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/blog-post</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/booking-page</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.70</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/contact</loc>
-    <lastmod>2025-09-21</lastmod>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.80</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/emergency</loc>
-    <lastmod>2025-09-21</lastmod>
+    <lastmod>2025-09-25</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/gallery</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/landing-page</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/privacy-policy</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/restoration-landing</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/services</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://callkaidsroofing.com.au/thank-you</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.75</priority>
   </url>
   <url>
     <loc>https://callkaidsroofing.com.au/warranty</loc>
-    <lastmod>2025-09-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2025-09-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.60</priority>
+  </url>
+  <url>
+    <loc>https://callkaidsroofing.com.au/privacy-policy</loc>
+    <lastmod>2025-09-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.50</priority>
   </url>
 </urlset>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,23 @@
+import { SEOHead } from '@/components/SEOHead';
+
+type SEOProps = {
+  title?: string;
+  description?: string;
+  canonical: string;
+  keywords?: string;
+  ogImage?: string;
+  structuredData?: object;
+};
+
+export function SEO({ title, description, canonical, keywords, ogImage, structuredData }: SEOProps) {
+  return (
+    <SEOHead
+      title={title}
+      description={description}
+      keywords={keywords}
+      canonical={canonical}
+      ogImage={ogImage}
+      structuredData={structuredData}
+    />
+  );
+}

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -1,11 +1,12 @@
 import { Helmet } from 'react-helmet-async';
-import { useLocation } from 'react-router-dom';
+
+const SITE_URL = 'https://callkaidsroofing.com.au';
 
 interface SEOHeadProps {
   title?: string;
   description?: string;
   keywords?: string;
-  canonical?: string;
+  canonical: string;
   ogImage?: string;
   structuredData?: object;
 }
@@ -18,9 +19,9 @@ export const SEOHead = ({
   ogImage = "https://callkaidsroofing.com.au/og-image.jpg",
   structuredData
 }: SEOHeadProps) => {
-  const location = useLocation();
-
-  const canonicalUrl = canonical || `https://callkaidsroofing.com.au${location.pathname}${location.search}`;
+  const canonicalUrl = canonical.startsWith('http')
+    ? canonical
+    : `${SITE_URL}${canonical.startsWith('/') ? canonical : `/${canonical}`}`;
 
   const defaultStructured = {
     "@context": "https://schema.org",

--- a/src/components/services/__tests__/service-page-layout.test.tsx
+++ b/src/components/services/__tests__/service-page-layout.test.tsx
@@ -4,8 +4,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { ServicePageLayout } from '@/components/services/service-page-layout';
 import type { ServiceCta } from '@/components/services/service-ctas';
 
-vi.mock('@/components/SEOHead', () => ({
-  SEOHead: ({ title }: { title: string }) => <div data-testid="seo-head">{title}</div>
+vi.mock('@/components/SEO', () => ({
+  SEO: ({ title, canonical }: { title: string; canonical: string }) => (
+    <div data-testid="seo-head" data-canonical={canonical}>
+      {title}
+    </div>
+  )
 }));
 
 vi.mock('@/components/StructuredData', () => ({
@@ -22,7 +26,11 @@ describe('ServicePageLayout', () => {
     render(
       <MemoryRouter>
         <ServicePageLayout
-          seo={{ title: 'Example Service', description: 'Example description' }}
+          seo={{
+            title: 'Example Service',
+            description: 'Example description',
+            canonical: 'https://example.com/services/example'
+          }}
           hero={{ title: 'Hero Title', subtitle: 'Hero Subtitle' }}
           ctas={ctas}
           trustSignals={['Licensed & insured']}

--- a/src/components/services/service-page-layout.tsx
+++ b/src/components/services/service-page-layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { StructuredData } from '@/components/StructuredData';
 import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
 import { cn } from '@/lib/utils';
@@ -9,6 +9,8 @@ interface ServicePageLayoutProps {
   seo: {
     title: string;
     description: string;
+    canonical: string;
+    keywords?: string;
   };
   hero: {
     title: string;
@@ -43,7 +45,12 @@ const ServicePageLayout = ({
 }: ServicePageLayoutProps) => {
   return (
     <div className={cn('min-h-screen bg-gradient-to-b from-background to-muted/10', className)}>
-      <SEOHead title={seo.title} description={seo.description} />
+      <SEO
+        title={seo.title}
+        description={seo.description}
+        canonical={seo.canonical}
+        keywords={seo.keywords}
+      />
       {structuredData ? (
         <StructuredData
           type="service"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,15 +1,16 @@
 import { Button } from '@/components/ui/button';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Phone, MapPin, Award, Users, Clock, Shield } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const About = () => {
   return (
     <div className="min-h-screen">
-      <SEOHead
+      <SEO
         title="About Call Kaids Roofing | Clyde North Roofing Specialist"
         description="Meet Kaidyn Brownlie – the Clyde North local behind Call Kaids Roofing. Discover the story, service area and workmanship that sets our SE Melbourne roofing crew apart."
         keywords="Call Kaids Roofing about, Clyde North roofer story, local roofing specialist"
+        canonical="https://callkaidsroofing.com.au/about"
       />
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-br from-primary/5 to-primary/10">

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -8,7 +8,7 @@ import { OptimizedImage } from "@/components/OptimizedImage";
 import { Clock, User, ArrowRight, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { SeoAnalysisWidget } from "@/components/SeoAnalysisWidget";
-import { SEOHead } from "@/components/SEOHead";
+import { SEO } from "@/components/SEO";
 
 export default function Blog() {
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
@@ -27,10 +27,11 @@ export default function Blog() {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Roofing Blog - Expert Tips & Guides | Call Kaids Roofing"
         description="Expert roofing advice, maintenance tips, and industry insights for Melbourne homeowners. Professional guides on roof restoration, repairs, and protection."
         keywords="roofing blog, Melbourne roofing tips, roof maintenance guides, roofing advice, Call Kaids Roofing"
+        canonical="https://callkaidsroofing.com.au/blog"
       />
 
       <div className="min-h-screen bg-gradient-to-br from-background via-background/50 to-primary/5">

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Clock, User, ArrowLeft, ArrowRight, Share2, Calendar } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { Helmet } from "react-helmet-async";
-import { SEOHead } from "@/components/SEOHead";
+import { SEO } from "@/components/SEO";
 
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
@@ -35,12 +35,15 @@ export default function BlogPost() {
     }
   };
 
+  const canonicalUrl = `https://callkaidsroofing.com.au/blog/${post.slug}`;
+
   return (
     <>
-      <SEOHead
+      <SEO
         title={`${post.title} | Call Kaids Roofing Blog`}
         description={post.excerpt}
         keywords={post.tags.join(", ")}
+        canonical={canonicalUrl}
       />
 
       <Helmet>

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -8,7 +8,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Phone, Mail, MapPin, Clock, CheckCircle, Star, Shield, Award, Zap } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import { SEOHead } from '@/components/SEOHead';
+import { Helmet } from 'react-helmet-async';
+import { SEO } from '@/components/SEO';
 import { StructuredData } from '@/components/StructuredData';
 import { OptimizedBackgroundSection } from '@/components/OptimizedBackgroundSection';
 import { OptimizedImage } from '@/components/OptimizedImage';
@@ -187,11 +188,15 @@ const BookingPage = () => {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Book Your Free Roof Quote | Call Kaids Roofing | Same Day Response"
         description="Book your free roof quote today. Same-day response, 10-year warranty, premium materials. Serving all Southeast Melbourne suburbs. Call 0435 900 709"
         keywords="book roof quote Melbourne, free roof inspection, roof quote Clyde North, emergency roof repairs booking"
+        canonical="https://callkaidsroofing.com.au/"
       />
+      <Helmet>
+        <meta name="robots" content="noindex,follow" />
+      </Helmet>
       <StructuredData type="contact" />
       
       <div className="min-h-screen bg-gradient-to-br from-primary/5 via-secondary/10 to-primary/15">

--- a/src/pages/Bundles.tsx
+++ b/src/pages/Bundles.tsx
@@ -45,7 +45,8 @@ const Bundles = () => {
       seo={{
         title: 'Roof Bundle Deals Clyde North – Save More | Call Kaids Roofing',
         description:
-          'Save 10–20% by combining services in one visit. Choose from ridge, cleaning, leak, and maintenance bundles. Serving Clyde North & SE Melbourne with transparent fixed pricing and licensed trades.'
+          'Save 10–20% by combining services in one visit. Choose from ridge, cleaning, leak, and maintenance bundles. Serving Clyde North & SE Melbourne with transparent fixed pricing and licensed trades.',
+        canonical: 'https://callkaidsroofing.com.au/bundles'
       }}
       hero={{
         title: 'Bundle Deals',

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,16 +1,17 @@
 import { Button } from '@/components/ui/button';
 import { Phone, Mail, MapPin, Clock, CheckCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { EnhancedContactForm } from '@/components/EnhancedContactForm';
 
 const Contact = () => {
   return (
     <>
-      <SEOHead
+      <SEO
         title="Contact Call Kaids Roofing | Direct to Owner | Southeast Melbourne"
         description="Talk direct to Kaidyn Brownlie, owner of Call Kaids Roofing. No call centres, no BS. Phone 0435 900 709 for immediate response. Free quotes, emergency repairs."
         keywords="contact roofer Melbourne, Clyde North roofing, emergency roof repairs, free roof quote, direct contact roofer"
+        canonical="https://callkaidsroofing.com.au/contact"
       />
       <div className="min-h-screen">
       {/* Hero Section */}

--- a/src/pages/Emergency.tsx
+++ b/src/pages/Emergency.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Phone, Clock, MapPin, AlertTriangle, CheckCircle, Shield } from 'lucide-react';
 
 const Emergency = () => {
@@ -30,10 +30,11 @@ const Emergency = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead
+      <SEO
         title="Emergency Roof Repairs Clyde North & SE Melbourne | Call Kaids Roofing"
         description="Same-day emergency roof repairs for Clyde North, Cranbourne, Berwick and surrounding suburbs. Call 0435 900 709 for rapid leak control and storm damage support."
         keywords="emergency roof repairs Clyde North, storm damage roofing Melbourne, urgent roof repair"
+        canonical="https://callkaidsroofing.com.au/emergency"
       />
       {/* Hero Section */}
       <section className="py-20 bg-destructive text-destructive-foreground">

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -6,7 +6,7 @@ import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { ChevronLeft, ChevronRight, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Link } from 'react-router-dom';
 
 interface GalleryImage {
@@ -171,10 +171,11 @@ const Gallery = () => {
 
   return (
     <>
-      <SEOHead 
+      <SEO
         title="Project Gallery - Call Kaids Roofing | Before & After Transformations"
         description="View stunning before and after transformations from Call Kaids Roofing. Real projects across Melbourne's SE suburbs showcasing quality roof restorations, painting, and repairs."
         keywords="roof restoration before after, Melbourne roof transformations, roof painting gallery, ridge capping repairs, Call Kaids projects"
+        canonical="https://callkaidsroofing.com.au/gallery"
       />
       
       <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Phone, ArrowRight, CheckCircle, AlertTriangle, Star, Calendar } from 'lucide-react';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { StructuredData } from '@/components/StructuredData';
 import TrustIndicators from '@/components/TrustIndicators';
 import { OptimizedBackgroundSection } from '@/components/OptimizedBackgroundSection';
@@ -56,11 +56,12 @@ const Index = () => {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Call Kaids Roofing | Roof Restorations Clyde North & SE Melbourne"
         description="Local roofing experts in Clyde North. Roof restorations, painting, repairs & gutter cleaning with 10-year warranty. Call 0435 900 709 today."
         keywords="roof restorations Clyde North, roof painting southeast Melbourne, gutter cleaning Clyde North, roof repairs Berwick"
         ogImage="https://callkaidsroofing.com.au/lovable-uploads/80e5f731-db09-4c90-8350-01fcb1fe353d-1200.jpg"
+        canonical="https://callkaidsroofing.com.au/"
       />
       <StructuredData type="homepage" />
       <div className="page-transition">

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { SEOHead } from "@/components/SEOHead";
+import { SEO } from "@/components/SEO";
 import {
   Phone,
   CheckCircle,
@@ -126,10 +126,11 @@ export default function LandingPage() {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Emergency Roof Repairs Melbourne | Stop Leaks Fast | Call Kaids Roofing"
         description="24/7 emergency roof repair service across Melbourne. Professional leak detection & repairs. Free assessment, 10-year warranty. Call now: 0435 900 709"
         keywords="emergency roof repairs Melbourne, roof leak repair, urgent roofing service, 24/7 roof repairs, Melbourne roof emergency"
+        canonical="https://callkaidsroofing.com.au/emergency-landing"
         structuredData={structuredData}
       />
 

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,11 +1,12 @@
-import { SEOHead } from "@/components/SEOHead";
+import { SEO } from "@/components/SEO";
 
 export default function PrivacyPolicy() {
   return (
     <>
-      <SEOHead
+      <SEO
         title="Privacy Policy | Call Kaids Roofing"
         description="Privacy policy for Call Kaids Roofing. Learn how we collect, use and protect your personal information."
+        canonical="https://callkaidsroofing.com.au/privacy-policy"
       />
       
       <div className="min-h-screen bg-background">

--- a/src/pages/RestorationLanding.tsx
+++ b/src/pages/RestorationLanding.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
-import { SEOHead } from "@/components/SEOHead";
+import { SEO } from "@/components/SEO";
 import { 
   Phone, 
   CheckCircle, 
@@ -124,10 +124,11 @@ export default function RestorationLanding() {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Roof Restoration Melbourne | Transform Your Roof | Call Kaids Roofing"
         description="Professional roof restoration services across Melbourne. Complete roof makeover with painting, repointing & repairs. 10-year warranty. Free health check."
         keywords="roof restoration Melbourne, roof painting Melbourne, roof repointing, complete roof makeover, Melbourne roof restoration"
+        canonical="https://callkaidsroofing.com.au/restoration-landing"
         structuredData={structuredData}
       />
 

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { CheckCircle2, ArrowRight } from 'lucide-react';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { ServiceCtas, type ServiceCta } from '@/components/services/service-ctas';
 import { COMPANY_PHONE_DISPLAY, COMPANY_PHONE_TEL } from '@/constants/company';
 
@@ -105,9 +105,10 @@ const serviceAreas = [
 const Services = () => {
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-muted/10">
-      <SEOHead
+      <SEO
         title="Roofing Services Clyde North & SE Melbourne – 10-Year Warranty | Call Kaids Roofing"
         description="Explore our range of featured and additional roofing services in Clyde North and SE Melbourne. Benefit from Dulux products, a 10-year workmanship warranty, and a free roof health check."
+        canonical="https://callkaidsroofing.com.au/services"
       />
 
       <section className="bg-gradient-to-br from-primary via-primary/90 to-[#0B3B69] py-20 text-white">

--- a/src/pages/ThankYou.tsx
+++ b/src/pages/ThankYou.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { CheckCircle, Phone, Mail, Clock, Shield } from "lucide-react";
-import { SEOHead } from "@/components/SEOHead";
+import { Helmet } from "react-helmet-async";
+import { SEO } from "@/components/SEO";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
 export default function ThankYou() {
   return (
     <>
-      <SEOHead 
+      <SEO
         title="Thank You - Call Kaids Roofing"
         description="Thank you for your roofing enquiry. We'll contact you within 24 hours to discuss your project and arrange a free inspection."
-        canonical="/thank-you"
+        canonical="https://callkaidsroofing.com.au/thank-you"
       />
+      <Helmet>
+        <meta name="robots" content="noindex,follow" />
+      </Helmet>
       
       <div className="min-h-screen bg-gradient-to-b from-background to-accent/5">
         <div className="container mx-auto px-4 py-16">

--- a/src/pages/Warranty.tsx
+++ b/src/pages/Warranty.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Shield, CheckCircle, Phone, Clock, Award, AlertTriangle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
@@ -71,10 +71,11 @@ const Warranty = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead
+      <SEO
         title="Roofing Warranty | 10-Year Workmanship Guarantee | Call Kaids Roofing"
         description="Understand the 10-year workmanship and material warranty from Call Kaids Roofing. Covering Clyde North, Cranbourne, Berwick & SE Melbourne projects."
         keywords="roofing warranty Melbourne, roof restoration warranty, Call Kaids Roofing guarantee"
+        canonical="https://callkaidsroofing.com.au/warranty"
       />
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-br from-primary/5 to-primary/10">

--- a/src/pages/services/GutterCleaning.tsx
+++ b/src/pages/services/GutterCleaning.tsx
@@ -47,7 +47,8 @@ const GutterCleaning = () => {
       seo={{
         title: 'Gutter Cleaning Clyde North – Prevent Overflows | Call Kaids Roofing',
         description:
-          'Keep gutters and downpipes clear with professional cleaning and photo proof. Prevent water damage and foundation issues. Serving Clyde North & SE Melbourne.'
+          'Keep gutters and downpipes clear with professional cleaning and photo proof. Prevent water damage and foundation issues. Serving Clyde North & SE Melbourne.',
+        canonical: 'https://callkaidsroofing.com.au/services/gutter-cleaning'
       }}
       hero={{
         title: 'Gutter Cleaning',

--- a/src/pages/services/HealthCheck.tsx
+++ b/src/pages/services/HealthCheck.tsx
@@ -44,7 +44,8 @@ const HealthCheck = () => {
       seo={{
         title: 'Free Roof Health Check Clyde North | Call Kaids Roofing',
         description:
-          'Catch problems before they leak. Get a free photo-based roof health check with a written report and fixed-price quote if issues are found. Trusted by 500+ homeowners in Clyde North & SE Melbourne.'
+          'Catch problems before they leak. Get a free photo-based roof health check with a written report and fixed-price quote if issues are found. Trusted by 500+ homeowners in Clyde North & SE Melbourne.',
+        canonical: 'https://callkaidsroofing.com.au/services/health-check'
       }}
       hero={{
         title: 'Free Roof Health Check',

--- a/src/pages/services/LeakDetection.tsx
+++ b/src/pages/services/LeakDetection.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -34,10 +34,11 @@ const LeakDetection = () => {
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Roof Leak Detection Melbourne | Emergency Leak Repair | Call Kaids Roofing"
         description="Professional roof leak detection in Southeast Melbourne. Find hidden leaks fast with advanced techniques. Emergency service available. Call 0435 900 709."
         keywords="roof leak detection Melbourne, roof leak repair, emergency roof repair, hidden roof leaks, Clyde North leak detection"
+        canonical="https://callkaidsroofing.com.au/services/leak-detection"
         structuredData={structuredData}
       />
 

--- a/src/pages/services/ReroofAndExtensions.tsx
+++ b/src/pages/services/ReroofAndExtensions.tsx
@@ -54,7 +54,8 @@ const ReroofAndExtensions = () => {
       seo={{
         title: 'Re-roof & Extensions Clyde North – Tie-in Specialists | Call Kaids Roofing',
         description:
-          'Full or partial re-roofs and seamless tie-ins for extensions with matched profiles and flashings. Serving Clyde North & SE Melbourne with compliance certification and a 10-year workmanship warranty.'
+          'Full or partial re-roofs and seamless tie-ins for extensions with matched profiles and flashings. Serving Clyde North & SE Melbourne with compliance certification and a 10-year workmanship warranty.',
+        canonical: 'https://callkaidsroofing.com.au/services/re-roof-extensions'
       }}
       hero={{
         title: 'Re-roof & Extensions',

--- a/src/pages/services/ResarkingAndBattening.tsx
+++ b/src/pages/services/ResarkingAndBattening.tsx
@@ -48,7 +48,8 @@ const ResarkingAndBattening = () => {
       seo={{
         title: 'Resarking & Battening Clyde North – Improve Waterproofing | Call Kaids Roofing',
         description:
-          'Renew sarking and battens for better waterproofing, insulation, and roof support. Serving Clyde North & SE Melbourne with a 10-year workmanship warranty and licensed trades.'
+          'Renew sarking and battens for better waterproofing, insulation, and roof support. Serving Clyde North & SE Melbourne with a 10-year workmanship warranty and licensed trades.',
+        canonical: 'https://callkaidsroofing.com.au/services/resarking-battening'
       }}
       hero={{
         title: 'Resarking & Battening',

--- a/src/pages/services/RoofCleaning.tsx
+++ b/src/pages/services/RoofCleaning.tsx
@@ -54,7 +54,8 @@ const RoofCleaning = () => {
       seo={{
         title: 'Roof Pressure Cleaning Clyde North – Remove Moss & Dirt | Call Kaids Roofing',
         description:
-          'Power wash your roof tiles to remove moss, lichen, and dirt. Restore colour and prepare for coating. Serving Clyde North & SE Melbourne with photo proof on completion.'
+          'Power wash your roof tiles to remove moss, lichen, and dirt. Restore colour and prepare for coating. Serving Clyde North & SE Melbourne with photo proof on completion.',
+        canonical: 'https://callkaidsroofing.com.au/services/roof-pressure-cleaning'
       }}
       hero={{
         title: 'Roof Pressure Cleaning',

--- a/src/pages/services/RoofPainting.tsx
+++ b/src/pages/services/RoofPainting.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Phone, CheckCircle, Clock, Shield, MapPin, Calendar, Palette, Home, DollarSign } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import ServiceSpecificForm from '@/components/ServiceSpecificForm';
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { StructuredData } from '@/components/StructuredData';
 import { OptimizedBackgroundSection } from '@/components/OptimizedBackgroundSection';
 
@@ -93,10 +93,11 @@ const RoofPainting = () => {
 
   return (
     <div className="min-h-screen">
-      <SEOHead
+      <SEO
         title="Roof Painting Melbourne | Tile & Metal Roof Coatings"
         description="Transform your home’s look with expert roof painting. Protective coatings, colour matched finishes, 10-year warranty. Serving SE Melbourne."
         keywords="roof painting Melbourne, tile roof painting Melbourne, metal roof coatings, Call Kaids Roofing"
+        canonical="https://callkaidsroofing.com.au/services/roof-painting"
       />
       <StructuredData 
         type="service" 

--- a/src/pages/services/RoofRepairs.tsx
+++ b/src/pages/services/RoofRepairs.tsx
@@ -55,7 +55,8 @@ const RoofRepairs = () => {
       seo={{
         title: 'Leak Repairs Clyde North – Fast & Reliable | Call Kaids Roofing',
         description:
-          'Stop roof leaks fast with professional repairs in Clyde North & SE Melbourne. Tile replacement, valley repair, and minor resealing with photo proof. Free roof health check included.'
+          'Stop roof leaks fast with professional repairs in Clyde North & SE Melbourne. Tile replacement, valley repair, and minor resealing with photo proof. Free roof health check included.',
+        canonical: 'https://callkaidsroofing.com.au/services/roof-repairs'
       }}
       hero={{
         title: 'Leak Repairs',

--- a/src/pages/services/RoofRepointing.tsx
+++ b/src/pages/services/RoofRepointing.tsx
@@ -48,7 +48,8 @@ const RoofRepointing = () => {
       seo={{
         title: 'Ridge Rebedding & Repointing Clyde North – 10-Year Warranty | Call Kaids Roofing',
         description:
-          'Secure your ridge caps with rebedding and repointing using flexible compounds. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and Dulux products.'
+          'Secure your ridge caps with rebedding and repointing using flexible compounds. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and Dulux products.',
+        canonical: 'https://callkaidsroofing.com.au/services/roof-repointing'
       }}
       hero={{
         title: 'Ridge Rebedding & Repointing',

--- a/src/pages/services/RoofRestoration.tsx
+++ b/src/pages/services/RoofRestoration.tsx
@@ -49,7 +49,8 @@ const RoofRestoration = () => {
       seo={{
         title: 'Full Roof Restoration Clyde North & SE Melbourne – 10-Year Warranty | Call Kaids Roofing',
         description:
-          'Restore your roof with cleaning, rebedding, repointing, and Dulux membrane coating. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and photo proof.'
+          'Restore your roof with cleaning, rebedding, repointing, and Dulux membrane coating. Serving Clyde North and SE Melbourne with a 10-year workmanship warranty and photo proof.',
+        canonical: 'https://callkaidsroofing.com.au/services/roof-restoration'
       }}
       hero={{
         title: 'Full Roof Restorations',

--- a/src/pages/services/TileReplacement.tsx
+++ b/src/pages/services/TileReplacement.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -29,15 +29,16 @@ const TileReplacement = () => {
     },
     "areaServed": ["Clyde North", "Berwick", "Officer", "Pakenham", "Cranbourne", "Southeast Melbourne"],
     "serviceType": "Roof Tile Replacement",
-    "url": "https://callkaidsroofing.com.au/tile-replacement"
+    "url": "https://callkaidsroofing.com.au/services/tile-replacement"
   };
 
   return (
     <>
-      <SEOHead
+      <SEO
         title="Broken Roof Tile Replacement Melbourne | Call Kaids Roofing"
         description="Professional broken roof tile replacement in Southeast Melbourne. Match existing tiles, prevent leaks. 10-year warranty. Call 0435 900 709."
         keywords="roof tile replacement Melbourne, broken tile repair, tile matching, roof leak repair, Clyde North tile replacement"
+        canonical="https://callkaidsroofing.com.au/services/tile-replacement"
         structuredData={structuredData}
       />
 

--- a/src/pages/services/ValleyIronReplacement.tsx
+++ b/src/pages/services/ValleyIronReplacement.tsx
@@ -55,7 +55,8 @@ const ValleyIronReplacement = () => {
       seo={{
         title: 'Valley Iron Replacement Clyde North – Prevent Leaks | Call Kaids Roofing',
         description:
-          'Replace rusted or damaged valley irons to ensure proper water runoff. Serving Clyde North & SE Melbourne with new sarking, secure edges, and a 10-year workmanship warranty.'
+          'Replace rusted or damaged valley irons to ensure proper water runoff. Serving Clyde North & SE Melbourne with new sarking, secure edges, and a 10-year workmanship warranty.',
+        canonical: 'https://callkaidsroofing.com.au/services/valley-iron-replacement'
       }}
       hero={{
         title: 'Valley Iron Replacement',

--- a/src/pages/services/suburbs/RoofPaintingClydeNorth.tsx
+++ b/src/pages/services/suburbs/RoofPaintingClydeNorth.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Brush, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofPaintingClydeNorth = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Painting Clyde North | Tile & Metal Roof Coatings"
         description="Clyde North roof painting with premium membranes, fast turnaround and 10-year warranty. Freshen new estates or revive original builds."
         keywords="roof painting Clyde North, roof coating Clyde North, tile roof painting Clyde North"
+        canonical="https://callkaidsroofing.com.au/services/roof-painting-clyde-north"
       />
 
       <section className="py-16 bg-primary/5">

--- a/src/pages/services/suburbs/RoofPaintingCranbourne.tsx
+++ b/src/pages/services/suburbs/RoofPaintingCranbourne.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, PaintRoller, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofPaintingCranbourne = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Painting Cranbourne | Tile & Metal Roof Coatings"
         description="Cranbourne roof painting specialists delivering sharp finishes, protective membranes and 10-year warranties. Colour matched to your suburb."
         keywords="roof painting Cranbourne, roof coating Cranbourne, tile roof painting Cranbourne"
+        canonical="https://callkaidsroofing.com.au/services/roof-painting-cranbourne"
       />
 
       <section className="py-16 bg-secondary/5">

--- a/src/pages/services/suburbs/RoofPaintingPakenham.tsx
+++ b/src/pages/services/suburbs/RoofPaintingPakenham.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Palette, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofPaintingPakenham = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Painting Pakenham | Tile & Metal Roof Coatings"
         description="Transform your home’s look with expert roof painting. Protective coatings, colour matched finishes, 10-year warranty. Serving SE Melbourne."
         keywords="roof painting Pakenham, roof coating Pakenham, tile roof painting Pakenham"
+        canonical="https://callkaidsroofing.com.au/services/roof-painting-pakenham"
       />
 
       <section className="py-16 bg-primary/5">

--- a/src/pages/services/suburbs/RoofRestorationBerwick.tsx
+++ b/src/pages/services/suburbs/RoofRestorationBerwick.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofRestorationBerwick = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Restorations Berwick | Call Kaids Roofing SE Melbourne"
         description="High-end roof restoration for Berwick’s heritage homes and modern estates. Precision repairs, colour matched coatings and respectful site management."
         keywords="roof restoration Berwick, heritage roof repair Berwick, roof coating Berwick"
+        canonical="https://callkaidsroofing.com.au/services/roof-restoration-berwick"
       />
 
       <section className="py-16 bg-secondary/5">

--- a/src/pages/services/suburbs/RoofRestorationClydeNorth.tsx
+++ b/src/pages/services/suburbs/RoofRestorationClydeNorth.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofRestorationClydeNorth = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Restorations Clyde North | Call Kaids Roofing SE Melbourne"
         description="Bring your roof back to life with professional restorations. Serving Clyde North, Cranbourne, Berwick & surrounds. Honest quotes, lasting results."
         keywords="roof restoration Clyde North, roof repair Clyde North, ridge cap repointing Clyde North"
+        canonical="https://callkaidsroofing.com.au/services/roof-restoration-clyde-north"
       />
 
       <section className="py-16 bg-primary/5">

--- a/src/pages/services/suburbs/RoofRestorationCranbourne.tsx
+++ b/src/pages/services/suburbs/RoofRestorationCranbourne.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofRestorationCranbourne = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Restorations Cranbourne | Call Kaids Roofing SE Melbourne"
         description="Cranbourne roof restoration specialists handling weathered tiles, moss build-up and storm wear. Local crew with 10-year workmanship warranty."
         keywords="roof restoration Cranbourne, moss removal Cranbourne, roof repairs Cranbourne"
+        canonical="https://callkaidsroofing.com.au/services/roof-restoration-cranbourne"
       />
 
       <section className="py-16 bg-secondary/5">

--- a/src/pages/services/suburbs/RoofRestorationMountEliza.tsx
+++ b/src/pages/services/suburbs/RoofRestorationMountEliza.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofRestorationMountEliza = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Restorations Mount Eliza | Call Kaids Roofing SE Melbourne"
         description="Coastal roof restoration for Mount Eliza homes facing salt spray and bay winds. Premium coatings, meticulous repairs and 10-year warranties."
         keywords="roof restoration Mount Eliza, coastal roof repair Mount Eliza, roof coating Mount Eliza"
+        canonical="https://callkaidsroofing.com.au/services/roof-restoration-mount-eliza"
       />
 
       <section className="py-16 bg-blue-50">

--- a/src/pages/services/suburbs/RoofRestorationPakenham.tsx
+++ b/src/pages/services/suburbs/RoofRestorationPakenham.tsx
@@ -1,4 +1,4 @@
-import { SEOHead } from '@/components/SEOHead';
+import { SEO } from '@/components/SEO';
 import { Button } from '@/components/ui/button';
 import { OptimizedImage } from '@/components/OptimizedImage';
 import { CheckCircle, Phone } from 'lucide-react';
@@ -7,10 +7,11 @@ import { Link } from 'react-router-dom';
 const RoofRestorationPakenham = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SEOHead
+      <SEO
         title="Roof Restorations Pakenham | Call Kaids Roofing SE Melbourne"
         description="Restore weathered Pakenham roofs with cleaning, repairs and membrane coatings designed for the hills and winter frost. Local crew, honest pricing."
         keywords="roof restoration Pakenham, roof repair Pakenham, membrane coating Pakenham"
+        canonical="https://callkaidsroofing.com.au/services/roof-restoration-pakenham"
       />
 
       <section className="py-16 bg-accent/20">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,5 +26,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- replace robots.txt and sitemap.xml with canonical host entries
- add Netlify-style redirects to enforce non-www host and service slugs
- introduce an SEO helper and update pages/service layout to emit absolute canonicals while noindexing thin routes

## Testing
- npm run lint
- npm run typecheck
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d497ea25cc8320ae9002970a615fad